### PR TITLE
Update new repoName in build failure notification

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -31,6 +31,6 @@ jobs:
           --data "{
             \"event_type\": \"notify-build-failure\",
             \"client_payload\": {
-              \"repoName\": \"ballerinax-openapi-connectors\"
+              \"repoName\": \"openapi-connectors\"
             }
           }"


### PR DESCRIPTION
# Description
Earlier the name of this repo was `ballerinax-openapi-connectors`
But now we have renamed it as `openapi-connectors`

In this PR, the repo name in build failure notification is updated

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 