### PR TITLE
Add distribution as `slbeta6` in Ballerina.toml

### DIFF
--- a/openapi/ably/Ballerina.toml
+++ b/openapi/ably/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Intelligence/Analytics", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/adp.paystatements/Ballerina.toml
+++ b/openapi/adp.paystatements/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Human Resources/HRMS", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/adp.workerpayrollinstructions/Ballerina.toml
+++ b/openapi/adp.workerpayrollinstructions/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Human Resources/HRMS", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/api2pdf/Ballerina.toml
+++ b/openapi/api2pdf/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Documents", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/apideck.accounting/Ballerina.toml
+++ b/openapi/apideck.accounting/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Accounting", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/apideck.lead/Ballerina.toml
+++ b/openapi/apideck.lead/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/apideck.proxy/Ballerina.toml
+++ b/openapi/apideck.proxy/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Server Monitoring", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/apple.appstore/Ballerina.toml
+++ b/openapi/apple.appstore/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Lifestyle & Entertainment/App Store", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/asana/Ballerina.toml
+++ b/openapi/asana/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Productivity/Project Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/atspoke/Ballerina.toml
+++ b/openapi/atspoke/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Support/Customer Support", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/automata/Ballerina.toml
+++ b/openapi/automata/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Intelligence/Analytics", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/avaza/Ballerina.toml
+++ b/openapi/avaza/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Productivity/Project Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/azure.anomalydetector/Ballerina.toml
+++ b/openapi/azure.anomalydetector/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Paid", "Vendor/Microsoft"]
 org = "ballerinax"

--- a/openapi/azure.datalake/Ballerina.toml
+++ b/openapi/azure.datalake/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Intelligence/Analytics", "Cost/Paid", "Vendor/Microsoft"]
 org = "ballerinax"

--- a/openapi/azure.iotcentral/Ballerina.toml
+++ b/openapi/azure.iotcentral/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Internet of Things/Device Management", "Cost/Paid", "Vendor/Microsoft"]
 org = "ballerinax"

--- a/openapi/azure.iothub/Ballerina.toml
+++ b/openapi/azure.iothub/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Internet of Things/Device Management", "Cost/Paid", "Vendor/Microsoft"]
 org = "ballerinax"

--- a/openapi/azure.keyvault/Ballerina.toml
+++ b/openapi/azure.keyvault/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Security & Identity Tools", "Cost/Paid", "Vendor/Microsoft"]
 org = "ballerinax"

--- a/openapi/azure.qnamaker/Ballerina.toml
+++ b/openapi/azure.qnamaker/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Freemium", "Vendor/Microsoft"]
 org = "ballerinax"

--- a/openapi/azure.sqldb/Ballerina.toml
+++ b/openapi/azure.sqldb/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 org = "ballerinax"
 name = "azure.sqldb"
 icon = "icon.png"

--- a/openapi/azure.textanalytics/Ballerina.toml
+++ b/openapi/azure.textanalytics/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Paid", "Vendor/Microsoft"]
 org = "ballerinax"

--- a/openapi/azure.timeseries/Ballerina.toml
+++ b/openapi/azure.timeseries/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Internet of Things/Device Management", "Cost/Paid", "Vendor/Microsoft"]
 org = "ballerinax"

--- a/openapi/beezup.merchant/Ballerina.toml
+++ b/openapi/beezup.merchant/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 org = "ballerinax"
 name = "beezup.merchant"
 version = "1.0.0"

--- a/openapi/bing.autosuggest/Ballerina.toml
+++ b/openapi/bing.autosuggest/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Freemium", "Vendor/Microsoft"]
 org = "ballerinax"

--- a/openapi/bintable/Ballerina.toml
+++ b/openapi/bintable/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Intelligence/Analytics", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/bisstats/Ballerina.toml
+++ b/openapi/bisstats/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Intelligence/Analytics", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/bitbucket/Ballerina.toml
+++ b/openapi/bitbucket/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Source Control", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/bitly/Ballerina.toml
+++ b/openapi/bitly/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Devtools", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/bmc.truesightpresentationserver/Ballerina.toml
+++ b/openapi/bmc.truesightpresentationserver/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Server Monitoring", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/botify/Ballerina.toml
+++ b/openapi/botify/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Website & App Building/Search Engine Optimization", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/box/Ballerina.toml
+++ b/openapi/box/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/File Management & Storage", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/brex.onboarding/Ballerina.toml
+++ b/openapi/brex.onboarding/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Contact Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/brex.team/Ballerina.toml
+++ b/openapi/brex.team/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Human Resources/HRMS", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/browshot/Ballerina.toml
+++ b/openapi/browshot/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Browser Tools", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/bulksms/Ballerina.toml
+++ b/openapi/bulksms/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Communication/Call & SMS", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/capsulecrm/Ballerina.toml
+++ b/openapi/capsulecrm/Ballerina.toml
@@ -1,9 +1,9 @@
 [package]
+distribution = "slbeta6"
 org = "ballerinax"
 name = "capsulecrm"
 icon = "icon.png"
 version = "1.0.0"
-distribution = "slbeta3"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Sales & CRM/Customer Relationship Management","Cost/Freemium"]

--- a/openapi/chaingateway/Ballerina.toml
+++ b/openapi/chaingateway/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Cryptocurrency", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/clever.data/Ballerina.toml
+++ b/openapi/clever.data/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Education/Elearning", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/cloudmersive.barcode/Ballerina.toml
+++ b/openapi/cloudmersive.barcode/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Security & Identity Tools", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/cloudmersive.currency/Ballerina.toml
+++ b/openapi/cloudmersive.currency/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Accounting", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/cloudmersive.security/Ballerina.toml
+++ b/openapi/cloudmersive.security/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Security & Identity Tools", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/cloudmersive.validate/Ballerina.toml
+++ b/openapi/cloudmersive.validate/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Security & Identity Tools", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/cloudmersive.virusscan/Ballerina.toml
+++ b/openapi/cloudmersive.virusscan/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Security & Identity Tools", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/constantcontact/Ballerina.toml
+++ b/openapi/constantcontact/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Marketing/Marketing Automation", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/covid19/Ballerina.toml
+++ b/openapi/covid19/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Lifestyle & Entertainment/News & Lifestyle", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/dataflowkit/Ballerina.toml
+++ b/openapi/dataflowkit/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Website & App Building/Web Scraper", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/dev.to/Ballerina.toml
+++ b/openapi/dev.to/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Marketing/Social Media Accounts", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/disqus/Ballerina.toml
+++ b/openapi/disqus/Ballerina.toml
@@ -1,9 +1,9 @@
 [package]
+distribution = "slbeta6"
 org = "ballerinax"
 name = "disqus"
 icon = "icon.png"
 version = "1.0.0"
-distribution = "slbeta3"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Website & App Building/Website Builders","Cost/Freemium"]

--- a/openapi/dracoon.public/Ballerina.toml
+++ b/openapi/dracoon.public/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/File Management & Storage", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/dropbox/Ballerina.toml
+++ b/openapi/dropbox/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/File Management & Storage", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/earthref.fiesta/Ballerina.toml
+++ b/openapi/earthref.fiesta/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Geographic Information Systems", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/ebay.account/Ballerina.toml
+++ b/openapi/ebay.account/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Commerce/eCommerce", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/ebay.analytics/Ballerina.toml
+++ b/openapi/ebay.analytics/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Commerce/eCommerce", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/ebay.browse/Ballerina.toml
+++ b/openapi/ebay.browse/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Commerce/eCommerce", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/ebay.compliance/Ballerina.toml
+++ b/openapi/ebay.compliance/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Commerce/eCommerce", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/ebay.finances/Ballerina.toml
+++ b/openapi/ebay.finances/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Commerce/eCommerce", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/ebay.inventory/Ballerina.toml
+++ b/openapi/ebay.inventory/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Commerce/eCommerce", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/ebay.listing/Ballerina.toml
+++ b/openapi/ebay.listing/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Commerce/eCommerce", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/ebay.logistics/Ballerina.toml
+++ b/openapi/ebay.logistics/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Commerce/eCommerce", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/ebay.metadata/Ballerina.toml
+++ b/openapi/ebay.metadata/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Commerce/eCommerce", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/ebay.negotiation/Ballerina.toml
+++ b/openapi/ebay.negotiation/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Commerce/eCommerce", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/ebay.recommendation/Ballerina.toml
+++ b/openapi/ebay.recommendation/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Commerce/eCommerce", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/edocs/Ballerina.toml
+++ b/openapi/edocs/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Documents", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/elmah/Ballerina.toml
+++ b/openapi/elmah/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Debug Tools", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/eventbrite/Ballerina.toml
+++ b/openapi/eventbrite/Ballerina.toml
@@ -1,9 +1,9 @@
 [package]
+distribution = "slbeta6"
 org = "ballerinax"
 name = "eventbrite"
 icon = "icon.png"
 version = "1.0.0"
-distribution = "slbeta3"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Marketing/Event Management","Cost/Freemium"]

--- a/openapi/exchangerates/Ballerina.toml
+++ b/openapi/exchangerates/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Accounting", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/extpose/Ballerina.toml
+++ b/openapi/extpose/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Browser Tools", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/facebook.ads/Ballerina.toml
+++ b/openapi/facebook.ads/Ballerina.toml
@@ -1,10 +1,10 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Marketing/Social Media Accounts", "Cost/Free"]
 org = "ballerinax"
 name = "facebook.ads"
 icon = "icon.png"
-distribution = "slbeta3"
 repository = "https://github.com/ballerina-platform/ballerinax-openapi-connectors"
 version = "1.0.0"
 authors = ["Ballerina"]

--- a/openapi/figshare/Ballerina.toml
+++ b/openapi/figshare/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Documents", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/file360/Ballerina.toml
+++ b/openapi/file360/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Documents", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/files.com/Ballerina.toml
+++ b/openapi/files.com/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/File Management & Storage", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/flatapi/Ballerina.toml
+++ b/openapi/flatapi/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Lifestyle & Entertainment/News & Lifestyle", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/fraudlabspro.frauddetection/Ballerina.toml
+++ b/openapi/fraudlabspro.frauddetection/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Security & Identity Tools", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/fraudlabspro.smsverification/Ballerina.toml
+++ b/openapi/fraudlabspro.smsverification/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Security & Identity Tools", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/freshbooks/Ballerina.toml
+++ b/openapi/freshbooks/Ballerina.toml
@@ -1,10 +1,10 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Accounting", "Cost/Paid"]
 org = "ballerinax"
 name = "freshbooks"
 icon = "icon.png"
-distribution="slbeta3"
 repository = "https://github.com/ballerina-platform/ballerinax-openapi-connectors"
 version = "1.0.0"
 authors = ["Ballerina"]

--- a/openapi/fungenerators.barcode/Ballerina.toml
+++ b/openapi/fungenerators.barcode/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Security & Identity Tools", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/fungenerators.uuid/Ballerina.toml
+++ b/openapi/fungenerators.uuid/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/giphy/Ballerina.toml
+++ b/openapi/giphy/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Images & Design", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/gitlab/Ballerina.toml
+++ b/openapi/gitlab/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Source Control", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/godaddy.abuse/Ballerina.toml
+++ b/openapi/godaddy.abuse/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Intelligence/Reporting", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/godaddy.aftermarket/Ballerina.toml
+++ b/openapi/godaddy.aftermarket/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Website & App Building/Website Builders", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/godaddy.agreements/Ballerina.toml
+++ b/openapi/godaddy.agreements/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Website & App Building/Website Builders", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/godaddy.certificates/Ballerina.toml
+++ b/openapi/godaddy.certificates/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Security & Identity Tools", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/godaddy.countries/Ballerina.toml
+++ b/openapi/godaddy.countries/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Website & App Building/Website Builders", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/godaddy.domains/Ballerina.toml
+++ b/openapi/godaddy.domains/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Website & App Building/Website Builders", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/godaddy.orders/Ballerina.toml
+++ b/openapi/godaddy.orders/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Website & App Building/Website Builders", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/godaddy.shopper/Ballerina.toml
+++ b/openapi/godaddy.shopper/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Website & App Building/Website Builders", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/godaddy.subscriptions/Ballerina.toml
+++ b/openapi/godaddy.subscriptions/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Website & App Building/Website Builders", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/googleapis.abusiveexperiencereport/Ballerina.toml
+++ b/openapi/googleapis.abusiveexperiencereport/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Intelligence/Reporting", "Cost/Free", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.appsscript/Ballerina.toml
+++ b/openapi/googleapis.appsscript/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Documents", "Cost/Free", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.bigquery.datatransfer/Ballerina.toml
+++ b/openapi/googleapis.bigquery.datatransfer/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Freemium", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.bigquery/Ballerina.toml
+++ b/openapi/googleapis.bigquery/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Databases", "Cost/Freemium", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.blogger/Ballerina.toml
+++ b/openapi/googleapis.blogger/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Blogs", "Cost/Free", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.books/Ballerina.toml
+++ b/openapi/googleapis.books/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Lifestyle & Entertainment/Books", "Cost/Freemium", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.classroom/Ballerina.toml
+++ b/openapi/googleapis.classroom/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Education/Elearning", "Cost/Free", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.cloudbillingaccount/Ballerina.toml
+++ b/openapi/googleapis.cloudbillingaccount/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Billing", "Cost/Freemium", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.cloudbuild/Ballerina.toml
+++ b/openapi/googleapis.cloudbuild/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Billing", "Cost/Paid", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.clouddatastore/Ballerina.toml
+++ b/openapi/googleapis.clouddatastore/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Databases", "Cost/Freemium", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.cloudfilestore/Ballerina.toml
+++ b/openapi/googleapis.cloudfilestore/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/File Management & Storage", "Cost/Paid", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.cloudfunctions/Ballerina.toml
+++ b/openapi/googleapis.cloudfunctions/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Freemium", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.cloudnaturallanguage/Ballerina.toml
+++ b/openapi/googleapis.cloudnaturallanguage/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Intelligence/Language Analysis", "Cost/Free", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.cloudpubsub/Ballerina.toml
+++ b/openapi/googleapis.cloudpubsub/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Data Ingestion", "Cost/Freemium", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.cloudscheduler/Ballerina.toml
+++ b/openapi/googleapis.cloudscheduler/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Freemium", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.cloudtalentsolution/Ballerina.toml
+++ b/openapi/googleapis.cloudtalentsolution/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Human Resources/Talent Acquisition", "Cost/Free", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.cloudtranslation/Ballerina.toml
+++ b/openapi/googleapis.cloudtranslation/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Education/Translator", "Cost/Free", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.discovery/Ballerina.toml
+++ b/openapi/googleapis.discovery/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Marketing/Ads & Conversion", "Cost/Free", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.docs/Ballerina.toml
+++ b/openapi/googleapis.docs/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Documents", "Cost/Freemium", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.manufacturercenter/Ballerina.toml
+++ b/openapi/googleapis.manufacturercenter/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Commerce/eCommerce", "Cost/Free", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.mybusiness/Ballerina.toml
+++ b/openapi/googleapis.mybusiness/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Commerce/eCommerce", "Cost/Free", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.oauth2/Ballerina.toml
+++ b/openapi/googleapis.oauth2/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Security & Identity Tools", "Cost/Freemium", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.retail/Ballerina.toml
+++ b/openapi/googleapis.retail/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Commerce/eCommerce", "Cost/Paid", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.slides/Ballerina.toml
+++ b/openapi/googleapis.slides/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Documents", "Cost/Freemium", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.tasks/Ballerina.toml
+++ b/openapi/googleapis.tasks/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Productivity/Task Management", "Cost/Free", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.vault/Ballerina.toml
+++ b/openapi/googleapis.vault/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/File Management & Storage", "Cost/Paid", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.vision/Ballerina.toml
+++ b/openapi/googleapis.vision/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Intelligence/Artificial Intelligence", "Cost/Freemium", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.youtube.analytics/Ballerina.toml
+++ b/openapi/googleapis.youtube.analytics/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Intelligence/Analytics", "Cost/Free", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.youtube.data/Ballerina.toml
+++ b/openapi/googleapis.youtube.data/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Video & Audio", "Cost/Free", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/googleapis.youtube.reporting/Ballerina.toml
+++ b/openapi/googleapis.youtube.reporting/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Intelligence/Reporting", "Cost/Free", "Vendor/Google"]
 org = "ballerinax"

--- a/openapi/gotomeeting/Ballerina.toml
+++ b/openapi/gotomeeting/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Communication/Video Conferncing", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/gototraining/Ballerina.toml
+++ b/openapi/gototraining/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Communication/Video Conferncing", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/gotowebinar/Ballerina.toml
+++ b/openapi/gotowebinar/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Communication/Video Conferncing", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/graphhopper.directions/Ballerina.toml
+++ b/openapi/graphhopper.directions/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/hubspot.analytics/Ballerina.toml
+++ b/openapi/hubspot.analytics/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Intelligence/Analytics", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/hubspot.crm.company/Ballerina.toml
+++ b/openapi/hubspot.crm.company/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/hubspot.crm.contact/Ballerina.toml
+++ b/openapi/hubspot.crm.contact/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Contact Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/hubspot.crm.deal/Ballerina.toml
+++ b/openapi/hubspot.crm.deal/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/hubspot.crm.feedback/Ballerina.toml
+++ b/openapi/hubspot.crm.feedback/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/hubspot.crm.import/Ballerina.toml
+++ b/openapi/hubspot.crm.import/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/hubspot.crm.lineitem/Ballerina.toml
+++ b/openapi/hubspot.crm.lineitem/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/hubspot.crm.pipeline/Ballerina.toml
+++ b/openapi/hubspot.crm.pipeline/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/hubspot.crm.product/Ballerina.toml
+++ b/openapi/hubspot.crm.product/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/hubspot.crm.property/Ballerina.toml
+++ b/openapi/hubspot.crm.property/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/hubspot.crm.quote/Ballerina.toml
+++ b/openapi/hubspot.crm.quote/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/hubspot.crm.schema/Ballerina.toml
+++ b/openapi/hubspot.crm.schema/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/hubspot.crm.ticket/Ballerina.toml
+++ b/openapi/hubspot.crm.ticket/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/hubspot.events/Ballerina.toml
+++ b/openapi/hubspot.events/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Marketing/Event Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/hubspot.files/Ballerina.toml
+++ b/openapi/hubspot.files/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/File Management & Storage", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/hubspot.marketing/Ballerina.toml
+++ b/openapi/hubspot.marketing/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Marketing/Marketing Automation", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/icons8/Ballerina.toml
+++ b/openapi/icons8/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Images & Design", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/insightly.custom/Ballerina.toml
+++ b/openapi/insightly.custom/Ballerina.toml
@@ -1,10 +1,10 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Freemium"]
 org = "ballerinax"
 name = "insightly.custom"
 icon = "icon.png"
-distribution="slbeta3"
 repository = "https://github.com/ballerina-platform/ballerinax-openapi-connectors"
 version = "1.0.0"
 authors = ["Ballerina"]

--- a/openapi/instagram.bussiness/Ballerina.toml
+++ b/openapi/instagram.bussiness/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Marketing/Social Media Accounts", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/instagram/Ballerina.toml
+++ b/openapi/instagram/Ballerina.toml
@@ -1,10 +1,10 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Marketing/Social Media Accounts", "Cost/Free"]
 org = "ballerinax"
 name = "instagram"
 icon = "icon.png"
-distribution= "slbeta3"
 repository = "https://github.com/ballerina-platform/ballerinax-openapi-connectors"
 version = "1.0.0"
 authors = ["Ballerina"]

--- a/openapi/interzoid.convertcurrency/Ballerina.toml
+++ b/openapi/interzoid.convertcurrency/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Accounting", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/interzoid.currencyrate/Ballerina.toml
+++ b/openapi/interzoid.currencyrate/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Accounting", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/interzoid.emailinfo/Ballerina.toml
+++ b/openapi/interzoid.emailinfo/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/interzoid.globalnumberinfo/Ballerina.toml
+++ b/openapi/interzoid.globalnumberinfo/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/interzoid.globalpageload/Ballerina.toml
+++ b/openapi/interzoid.globalpageload/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/interzoid.globaltime/Ballerina.toml
+++ b/openapi/interzoid.globaltime/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/interzoid.statedata/Ballerina.toml
+++ b/openapi/interzoid.statedata/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/interzoid.weatherzip/Ballerina.toml
+++ b/openapi/interzoid.weatherzip/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/interzoid.zipinfo/Ballerina.toml
+++ b/openapi/interzoid.zipinfo/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/ip2whois/Ballerina.toml
+++ b/openapi/ip2whois/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/ipgeolocation/Ballerina.toml
+++ b/openapi/ipgeolocation/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Geographic Information Systems", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/iptwist/Ballerina.toml
+++ b/openapi/iptwist/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Geographic Information Systems", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/iris.disputeresponder/Ballerina.toml
+++ b/openapi/iris.disputeresponder/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/iris.esignature/Ballerina.toml
+++ b/openapi/iris.esignature/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/iris.helpdesk/Ballerina.toml
+++ b/openapi/iris.helpdesk/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/iris.lead/Ballerina.toml
+++ b/openapi/iris.lead/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/iris.merchants/Ballerina.toml
+++ b/openapi/iris.merchants/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/iris.residuals/Ballerina.toml
+++ b/openapi/iris.residuals/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/iris.subscriptions/Ballerina.toml
+++ b/openapi/iris.subscriptions/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/isbndb/Ballerina.toml
+++ b/openapi/isbndb/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Lifestyle & Entertainment/Books", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/isendpro/Ballerina.toml
+++ b/openapi/isendpro/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Communication/Call & SMS", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/jira/Ballerina.toml
+++ b/openapi/jira/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Productivity/Project Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/journey.io/Ballerina.toml
+++ b/openapi/journey.io/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Intelligence/Analytics", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/karbon/Ballerina.toml
+++ b/openapi/karbon/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 org = "ballerinax"
 name = "karbon"
 icon = "icon.png"

--- a/openapi/kinto/Ballerina.toml
+++ b/openapi/kinto/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Website & App Building/App Builders", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/launchdarkly/Ballerina.toml
+++ b/openapi/launchdarkly/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Productivity/Project Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/leanix.integrationapi/Ballerina.toml
+++ b/openapi/leanix.integrationapi/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Enterprise Architecture Tools", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/listen.notes/Ballerina.toml
+++ b/openapi/listen.notes/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Video & Audio", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/livestorm/Ballerina.toml
+++ b/openapi/livestorm/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Communication/Video Conferncing", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/logoraisr/Ballerina.toml
+++ b/openapi/logoraisr/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Images And Design", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/mailchimp/Ballerina.toml
+++ b/openapi/mailchimp/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Marketing/Email Newsletters", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/mailscript/Ballerina.toml
+++ b/openapi/mailscript/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Communication/Mail", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/mathtools.numbers/Ballerina.toml
+++ b/openapi/mathtools.numbers/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Education/eLearning", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/medium/Ballerina.toml
+++ b/openapi/medium/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Blogs", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/microsoft.dynamics365businesscentral/Ballerina.toml
+++ b/openapi/microsoft.dynamics365businesscentral/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Management/ERP", "Cost/Paid", "Vendor/Microsoft"]
 org = "ballerinax"

--- a/openapi/mitto.sms/Ballerina.toml
+++ b/openapi/mitto.sms/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Communication/Call & SMS", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/namsor/Ballerina.toml
+++ b/openapi/namsor/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Lifestyle & Entertainment/News & Lifestyle", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/neutrino/Ballerina.toml
+++ b/openapi/neutrino/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Website & App Building/App Builders", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/newsapi/Ballerina.toml
+++ b/openapi/newsapi/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Lifestyle & Entertainment/News & Lifestyle", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/notion/Ballerina.toml
+++ b/openapi/notion/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Productivity/Project Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/nowpayments/Ballerina.toml
+++ b/openapi/nowpayments/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Payment", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/nytimes.archive/Ballerina.toml
+++ b/openapi/nytimes.archive/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Lifestyle & Entertainment/News & Lifestyle", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/nytimes.articlesearch/Ballerina.toml
+++ b/openapi/nytimes.articlesearch/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Lifestyle & Entertainment/News & Lifestyle", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/nytimes.books/Ballerina.toml
+++ b/openapi/nytimes.books/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Lifestyle & Entertainment/News & Lifestyle", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/nytimes.mostpopular/Ballerina.toml
+++ b/openapi/nytimes.mostpopular/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Lifestyle & Entertainment/News & Lifestyle", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/nytimes.moviereviews/Ballerina.toml
+++ b/openapi/nytimes.moviereviews/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Lifestyle & Entertainment/News & Lifestyle", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/nytimes.newswire/Ballerina.toml
+++ b/openapi/nytimes.newswire/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Lifestyle & Entertainment/News & Lifestyle", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/nytimes.semantic/Ballerina.toml
+++ b/openapi/nytimes.semantic/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Lifestyle & Entertainment/News & Lifestyle", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/nytimes.timestags/Ballerina.toml
+++ b/openapi/nytimes.timestags/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Lifestyle & Entertainment/News & Lifestyle", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/nytimes.topstories/Ballerina.toml
+++ b/openapi/nytimes.topstories/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Lifestyle & Entertainment/News & Lifestyle", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/ocpi/Ballerina.toml
+++ b/openapi/ocpi/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/odweather/Ballerina.toml
+++ b/openapi/odweather/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Lifestyle & Entertainment/News & Lifestyle", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/onepassword/Ballerina.toml
+++ b/openapi/onepassword/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Security & Identity Tools", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/openair/Ballerina.toml
+++ b/openapi/openair/Ballerina.toml
@@ -1,10 +1,10 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Productivity/Project Management", "Cost/Paid"]
 org = "ballerinax"
 name = "openair"
 icon = "icon.png"
-distribution = "slbeta3"
 repository = "https://github.com/ballerina-platform/ballerinax-openapi-connectors"
 version = "1.0.1"
 authors = ["Ballerina"]

--- a/openapi/opendesign/Ballerina.toml
+++ b/openapi/opendesign/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Images & Design", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/openfigi/Ballerina.toml
+++ b/openapi/openfigi/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Accounting", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/openweathermap/Ballerina.toml
+++ b/openapi/openweathermap/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Lifestyle & Entertainment/News & Lifestyle", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/optimizely/Ballerina.toml
+++ b/openapi/optimizely/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Testing Tools", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/optirtc.public/Ballerina.toml
+++ b/openapi/optirtc.public/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Intelligence/Analytics", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/optitune/Ballerina.toml
+++ b/openapi/optitune/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Internet of Things/Device Management", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/orbitcrm/Ballerina.toml
+++ b/openapi/orbitcrm/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/owler/Ballerina.toml
+++ b/openapi/owler/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Intelligence/Analytics", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/pagerduty/Ballerina.toml
+++ b/openapi/pagerduty/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Support/Customer Support", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/paylocity/Ballerina.toml
+++ b/openapi/paylocity/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Payroll", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/paypal.orders/Ballerina.toml
+++ b/openapi/paypal.orders/Ballerina.toml
@@ -1,9 +1,9 @@
 [package]
+distribution = "slbeta6"
 org = "ballerinax"
 name = "paypal.orders"
 icon = "icon.png"
 version = "1.0.0"
-distribution = "slbeta3"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Finance/Payment","Cost/Freemium"]

--- a/openapi/paypal.payments/Ballerina.toml
+++ b/openapi/paypal.payments/Ballerina.toml
@@ -1,9 +1,9 @@
 [package]
+distribution = "slbeta6"
 org = "ballerinax"
 name = "paypal.payments"
 icon = "icon.png"
 version = "1.0.0"
-distribution = "slbeta3"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Finance/Payment","Cost/Freemium"]

--- a/openapi/pdfbroker/Ballerina.toml
+++ b/openapi/pdfbroker/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Documents", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/pipedrive/Ballerina.toml
+++ b/openapi/pipedrive/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Sales & CRM/Customer Relationship Management", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/plaid/Ballerina.toml
+++ b/openapi/plaid/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Accounting", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/pocketsmith/Ballerina.toml
+++ b/openapi/pocketsmith/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Asset Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/power.bi/Ballerina.toml
+++ b/openapi/power.bi/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Intelligence/Analytics", "Cost/Paid", "Vendor/Microsoft"]
 org = "ballerinax"

--- a/openapi/powertoolsdeveloper.collections/Ballerina.toml
+++ b/openapi/powertoolsdeveloper.collections/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Website & App Building/App Builders", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/powertoolsdeveloper.data/Ballerina.toml
+++ b/openapi/powertoolsdeveloper.data/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Website & App Building/App Builders", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/powertoolsdeveloper.datetime/Ballerina.toml
+++ b/openapi/powertoolsdeveloper.datetime/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Website & App Building/App Builders", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/powertoolsdeveloper.files/Ballerina.toml
+++ b/openapi/powertoolsdeveloper.files/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Website & App Building/App Builders", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/powertoolsdeveloper.finance/Ballerina.toml
+++ b/openapi/powertoolsdeveloper.finance/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Website & App Building/App Builders", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/powertoolsdeveloper.math/Ballerina.toml
+++ b/openapi/powertoolsdeveloper.math/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Website & App Building/App Builders", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/powertoolsdeveloper.text/Ballerina.toml
+++ b/openapi/powertoolsdeveloper.text/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Website & App Building/App Builders", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/powertoolsdeveloper.weather/Ballerina.toml
+++ b/openapi/powertoolsdeveloper.weather/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Website & App Building/App Builders", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/prodpad/Ballerina.toml
+++ b/openapi/prodpad/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Productivity/Product Management", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/pushcut/Ballerina.toml
+++ b/openapi/pushcut/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Internet of Things/Device Management", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/quickbooks.online/Ballerina.toml
+++ b/openapi/quickbooks.online/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Accounting", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/readme/Ballerina.toml
+++ b/openapi/readme/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Documents", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/recurly/Ballerina.toml
+++ b/openapi/recurly/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Billing", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/ritekit/Ballerina.toml
+++ b/openapi/ritekit/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Marketing/Social Media Marketing", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/ronin/Ballerina.toml
+++ b/openapi/ronin/Ballerina.toml
@@ -1,9 +1,9 @@
 [package]
+distribution = "slbeta6"
 org = "ballerinax"
 name = "ronin"
 icon = "icon.png"
 version = "1.0.0"
-distribution = "slbeta3"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Finance/Billing","Cost/Paid"]

--- a/openapi/rumble.run/Ballerina.toml
+++ b/openapi/rumble.run/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Server Monitoring", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/sakari/Ballerina.toml
+++ b/openapi/sakari/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Communication/Call & SMS", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/samcart/Ballerina.toml
+++ b/openapi/samcart/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Commerce/eCommerce", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/saps4hana.itcm.accountreceivable/Ballerina.toml
+++ b/openapi/saps4hana.itcm.accountreceivable/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Management/ERP", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/saps4hana.itcm.agreement/Ballerina.toml
+++ b/openapi/saps4hana.itcm.agreement/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Management/ERP", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/saps4hana.itcm.currency/Ballerina.toml
+++ b/openapi/saps4hana.itcm.currency/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Management/ERP", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/saps4hana.itcm.customer/Ballerina.toml
+++ b/openapi/saps4hana.itcm.customer/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Management/ERP", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/saps4hana.itcm.customerhierarchy/Ballerina.toml
+++ b/openapi/saps4hana.itcm.customerhierarchy/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Management/ERP", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/saps4hana.itcm.organizationaldata/Ballerina.toml
+++ b/openapi/saps4hana.itcm.organizationaldata/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Management/ERP", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/saps4hana.itcm.product/Ballerina.toml
+++ b/openapi/saps4hana.itcm.product/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Management/ERP", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/saps4hana.itcm.producthierarchy/Ballerina.toml
+++ b/openapi/saps4hana.itcm.producthierarchy/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Management/ERP", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/saps4hana.itcm.promotion/Ballerina.toml
+++ b/openapi/saps4hana.itcm.promotion/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Management/ERP", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/saps4hana.itcm.uom/Ballerina.toml
+++ b/openapi/saps4hana.itcm.uom/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Management/ERP", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/saps4hana.itcm.user/Ballerina.toml
+++ b/openapi/saps4hana.itcm.user/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Management/ERP", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/selz/Ballerina.toml
+++ b/openapi/selz/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Commerce/eCommerce", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/sendgrid/Ballerina.toml
+++ b/openapi/sendgrid/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Marketing/Marketing Automation", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/servicenow/Ballerina.toml
+++ b/openapi/servicenow/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Support/Customer Support", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/shippit/Ballerina.toml
+++ b/openapi/shippit/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Commerce/eCommerce", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/shipwire.carrier/Ballerina.toml
+++ b/openapi/shipwire.carrier/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Commerce/eCommerce", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/shipwire.containers/Ballerina.toml
+++ b/openapi/shipwire.containers/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Commerce/eCommerce", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/shipwire.receivings/Ballerina.toml
+++ b/openapi/shipwire.receivings/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Commerce/eCommerce", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/shipwire.warehouse/Ballerina.toml
+++ b/openapi/shipwire.warehouse/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Commerce/eCommerce", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/shopify.admin/Ballerina.toml
+++ b/openapi/shopify.admin/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 org = "ballerinax"
 name = "shopify.admin"
 icon = "icon.png"

--- a/openapi/shortcut/Ballerina.toml
+++ b/openapi/shortcut/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 org = "ballerinax"
 name = "shortcut"
 icon = "icon.png"

--- a/openapi/shorten.rest/Ballerina.toml
+++ b/openapi/shorten.rest/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Marketing/Url Shortener", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/siemens.analytics.anomalydetection/Ballerina.toml
+++ b/openapi/siemens.analytics.anomalydetection/Ballerina.toml
@@ -1,9 +1,9 @@
 [package]
+distribution = "slbeta6"
 org = "ballerinax"
 name = "siemens.analytics.anomalydetection"
 icon = "icon.png"
 version = "1.0.0"
-distribution = "slbeta3"
 license = ["Apache-2.0"]
 keywords = ["Business Intelligence/Analytics", "Cost/Paid"]
 repository = "https://github.com/ballerina-platform/ballerinax-openapi-connectors"

--- a/openapi/siemens.iotandstorage.iotfileservice/Ballerina.toml
+++ b/openapi/siemens.iotandstorage.iotfileservice/Ballerina.toml
@@ -1,9 +1,9 @@
 [package]
+distribution = "slbeta6"
 org = "ballerinax"
 name = "siemens.iotandstorage.iotfileservice"
 icon = "icon.png"
 version = "1.0.0"
-distribution = "slbeta3"
 license = ["Apache-2.0"]
 keywords = ["Internet of Things/Device Management", "Cost/Paid"]
 repository = "https://github.com/ballerina-platform/ballerinax-openapi-connectors"

--- a/openapi/siemens.platformcore.identitymanagement/Ballerina.toml
+++ b/openapi/siemens.platformcore.identitymanagement/Ballerina.toml
@@ -1,10 +1,10 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Security & Identity Tools", "Cost/Freemium"]
 org = "ballerinax"
 name = "siemens.platformcore.identitymanagement"
 icon = "icon.png"
-distribution = "slbeta3"
 repository = "https://github.com/ballerina-platform/ballerinax-openapi-connectors"
 version = "1.0.1"
 authors = ["Ballerina"]

--- a/openapi/sinch.conversation/Ballerina.toml
+++ b/openapi/sinch.conversation/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Communication/Call & SMS", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/sinch.sms/Ballerina.toml
+++ b/openapi/sinch.sms/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Communication/Call & SMS", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/sinch.verification/Ballerina.toml
+++ b/openapi/sinch.verification/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Security & Identity Tools", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/sinch.voice/Ballerina.toml
+++ b/openapi/sinch.voice/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Communication/Call & SMS", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/soundcloud/Ballerina.toml
+++ b/openapi/soundcloud/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Video & Audio", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/spotify/Ballerina.toml
+++ b/openapi/spotify/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Video & Audio", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/spotto/Ballerina.toml
+++ b/openapi/spotto/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Internet of Things/Device Management", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/storecove/Ballerina.toml
+++ b/openapi/storecove/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Billing", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/stripe/Ballerina.toml
+++ b/openapi/stripe/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Payment", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/supportbee/Ballerina.toml
+++ b/openapi/supportbee/Ballerina.toml
@@ -1,9 +1,9 @@
 [package]
+distribution = "slbeta6"
 org = "ballerinax"
 name = "supportbee"
 icon = "icon.png"
 version = "1.0.0"
-distribution = "slbeta3"
 license= ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Support/Customer Support","Cost/Paid"]

--- a/openapi/symantotextanalytics/Ballerina.toml
+++ b/openapi/symantotextanalytics/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/techport/Ballerina.toml
+++ b/openapi/techport/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/text2data/Ballerina.toml
+++ b/openapi/text2data/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 org = "ballerinax"
 name = "text2data"
 icon = "icon.png"

--- a/openapi/themoviedb/Ballerina.toml
+++ b/openapi/themoviedb/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Video & Audio", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/trello/Ballerina.toml
+++ b/openapi/trello/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Productivity/Task Management", "Cost/Freeemium"]
 org = "ballerinax"

--- a/openapi/uber/Ballerina.toml
+++ b/openapi/uber/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Lifestyle & Entertainment/Ride-Hailing", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/vimeo/Ballerina.toml
+++ b/openapi/vimeo/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Video & Audio", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/visiblethread/Ballerina.toml
+++ b/openapi/visiblethread/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Intelligence/Language Analysis", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/vonage.numberinsight/Ballerina.toml
+++ b/openapi/vonage.numberinsight/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Communication/Call Tracking", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/vonage.numbers/Ballerina.toml
+++ b/openapi/vonage.numbers/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Communication/Call Tracking", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/vonage.sms/Ballerina.toml
+++ b/openapi/vonage.sms/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Communication/Call & SMS", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/vonage.verify/Ballerina.toml
+++ b/openapi/vonage.verify/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Communication/Call & SMS", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/vonage.voice/Ballerina.toml
+++ b/openapi/vonage.voice/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Communication/Call & SMS", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/webscraping.ai/Ballerina.toml
+++ b/openapi/webscraping.ai/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Website & App Building/Web Scraper", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/whatsapp.business/Ballerina.toml
+++ b/openapi/whatsapp.business/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Communication/Call & SMS", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/whohoststhis/Ballerina.toml
+++ b/openapi/whohoststhis/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/wordnik/Ballerina.toml
+++ b/openapi/wordnik/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Education/Dictionary", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/wordpress/Ballerina.toml
+++ b/openapi/wordpress/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Website & App Building/Website Builders", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/workday.absencemanagement/Ballerina.toml
+++ b/openapi/workday.absencemanagement/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 org = "ballerinax"
 name = "workday.absencemanagement"
 version = "1.0.0"

--- a/openapi/workday.accountspayable/Ballerina.toml
+++ b/openapi/workday.accountspayable/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Human Resources/HRM", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/workday.businessprocess/Ballerina.toml
+++ b/openapi/workday.businessprocess/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Human Resources/HRM", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/workday.common/Ballerina.toml
+++ b/openapi/workday.common/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Human Resources/HRM", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/workday.compensation/Ballerina.toml
+++ b/openapi/workday.compensation/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Human Resources/HRM", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/workday.connect/Ballerina.toml
+++ b/openapi/workday.connect/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Human Resources/HRM", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/workday.coreaccounting/Ballerina.toml
+++ b/openapi/workday.coreaccounting/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Accounting", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/workday.customeraccounts/Ballerina.toml
+++ b/openapi/workday.customeraccounts/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Accounting", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/workday.expense/Ballerina.toml
+++ b/openapi/workday.expense/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Accounting", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/workday.payroll/Ballerina.toml
+++ b/openapi/workday.payroll/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Accounting", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/worldbank/Ballerina.toml
+++ b/openapi/worldbank/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Business Intelligence/Analytics", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/worldtimeapi/Ballerina.toml
+++ b/openapi/worldtimeapi/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["IT Operations/Cloud Services", "Cost/Free"]
 org = "ballerinax"

--- a/openapi/xero.accounts/Ballerina.toml
+++ b/openapi/xero.accounts/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Accounting", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/xero.assets/Ballerina.toml
+++ b/openapi/xero.assets/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Asset Management", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/xero.bankfeeds/Ballerina.toml
+++ b/openapi/xero.bankfeeds/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Accounting", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/xero.files/Ballerina.toml
+++ b/openapi/xero.files/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Content & Files/Documents", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/xero.finance/Ballerina.toml
+++ b/openapi/xero.finance/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Accounting", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/xero.projects/Ballerina.toml
+++ b/openapi/xero.projects/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Productivity/Project Management", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/ynab/Ballerina.toml
+++ b/openapi/ynab/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Asset Management", "Cost/Paid"]
 org = "ballerinax"

--- a/openapi/yodlee/Ballerina.toml
+++ b/openapi/yodlee/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Finance/Asset Management", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/zendesk.support/Ballerina.toml
+++ b/openapi/zendesk.support/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Support/Customer Support", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/zendesk.voice/Ballerina.toml
+++ b/openapi/zendesk.voice/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Support/Customer Support", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/zoom/Ballerina.toml
+++ b/openapi/zoom/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 license = ["Apache-2.0"]
 keywords = ["Communication/Video Conferencing", "Cost/Freemium"]
 org = "ballerinax"

--- a/openapi/zuora.collection/Ballerina.toml
+++ b/openapi/zuora.collection/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 org = "ballerinax"
 name = "zuora.collection"
 version = "1.0.0"

--- a/openapi/zuora.revenue/Ballerina.toml
+++ b/openapi/zuora.revenue/Ballerina.toml
@@ -1,4 +1,5 @@
 [package]
+distribution = "slbeta6"
 org = "ballerinax"
 name = "zuora.revenue"
 version = "1.0.0"


### PR DESCRIPTION
# Description
- Fix https://github.com/ballerina-platform/ballerina-extended-library/issues/192
- Add distribution as `slbeta6` in Ballerina.toml of all the connectors
- Remove entries of `slbeta3` of this same case (totally 15 entries)

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 