### PR TITLE
Remove SNAPSHOT from godaddy.certificates version

### DIFF
--- a/openapi/godaddy.certificates/Ballerina.toml
+++ b/openapi/godaddy.certificates/Ballerina.toml
@@ -6,7 +6,7 @@ org = "ballerinax"
 name = "godaddy.certificates"
 icon = "icon.png"
 repository = "https://github.com/ballerina-platform/ballerinax-openapi-connectors"
-version = "1.0.2-SNAPSHOT"
+version = "1.0.2"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true


### PR DESCRIPTION
# Description
Previously we removed SNAPSHOT from the version of all the connectors.
Only in godaddy.certificates connector, it was missed.

In this PR, upcoming version of godaddy.certificates is corrected as `1.0.2` 

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 