### PR TITLE
Regenerate Vimeo connector with latest tool

### DIFF
--- a/openapi/vimeo/client.bal
+++ b/openapi/vimeo/client.bal
@@ -15,12 +15,11 @@
 // under the License.
 
 import ballerina/http;
-import ballerina/url;
 
 # Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint.
 public type ClientConfig record {|
     # Configurations related to client authentication
-    http:OAuth2ClientCredentialsGrantConfig|http:BearerTokenConfig|http:OAuth2RefreshTokenGrantConfig auth;
+    OAuth2ClientCredentialsGrantConfig|http:BearerTokenConfig|http:OAuth2RefreshTokenGrantConfig auth;
     # The HTTP version understood by the client
     string httpVersion = "1.1";
     # Configurations related to HTTP/1.x protocol
@@ -51,6 +50,13 @@ public type ClientConfig record {|
     http:ClientSecureSocket? secureSocket = ();
 |};
 
+# OAuth2 Client Credintials Grant Configs
+public type OAuth2ClientCredentialsGrantConfig record {|
+    *http:OAuth2ClientCredentialsGrantConfig;
+    # Token URL
+    string tokenUrl = "https://api.vimeo.com/oauth/access_token";
+|};
+
 # This is a generated connector for [Vimeo API v3.4](https://developer.vimeo.com/) OpenAPI specification.
 # The Vimeo API provides access to manage Vimeo platform. This includes management of videos, channels, albums, users etc.
 @display {label: "Vimeo", iconPath: "icon.png"}
@@ -66,16 +72,17 @@ public isolated client class Client {
     public isolated function init(ClientConfig clientConfig, string serviceUrl = "https://api.vimeo.com") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
+        return;
     }
     # Get an API specification
     #
     # + openapi - Return an OpenAPI specification. 
     # + return - Standard request. 
     remote isolated function getEndpoints(boolean? openapi = ()) returns Endpoint|error {
-        string  path = string `/`;
+        string resourcePath = string `/`;
         map<anydata> queryParam = {"openapi": openapi};
-        path = path + check getPathForQueryParam(queryParam);
-        Endpoint response = check self.clientEp-> get(path, targetType = Endpoint);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Endpoint response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all categories
@@ -86,10 +93,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The categories were returned. 
     remote isolated function getCategories(string? direction = (), decimal? page = (), decimal? perPage = (), string? sort = ()) returns Category[]|error {
-        string  path = string `/categories`;
+        string resourcePath = string `/categories`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Category[] response = check self.clientEp-> get(path, targetType = CategoryArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Category[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get a specific category
@@ -97,8 +104,8 @@ public isolated client class Client {
     # + category - The name of the category. 
     # + return - The category was returned. 
     remote isolated function getCategory(string category) returns Category|error {
-        string  path = string `/categories/${category}`;
-        Category response = check self.clientEp-> get(path, targetType = Category);
+        string resourcePath = string `/categories/${category}`;
+        Category response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the channels in a category
@@ -111,10 +118,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The channels were returned. 
     remote isolated function getCategoryChannels(string category, string? direction = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Channel[]|error {
-        string  path = string `/categories/${category}/channels`;
+        string resourcePath = string `/categories/${category}/channels`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Channel[] response = check self.clientEp-> get(path, targetType = ChannelArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Channel[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the groups in a category
@@ -127,10 +134,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The groups were returned. 
     remote isolated function getCategoryGroups(string category, string? direction = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Group[]|error {
-        string  path = string `/categories/${category}/groups`;
+        string resourcePath = string `/categories/${category}/groups`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Group[] response = check self.clientEp-> get(path, targetType = GroupArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Group[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the videos in a category
@@ -145,10 +152,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The videos were returned. 
     remote isolated function getCategoryVideos(string category, string? direction = (), string? filter = (), boolean? filterEmbeddable = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Video[]|error {
-        string  path = string `/categories/${category}/videos`;
+        string resourcePath = string `/categories/${category}/videos`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "filter_embeddable": filterEmbeddable, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Check for a video in a category
@@ -157,8 +164,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video belongs to the category. 
     remote isolated function checkCategoryForVideo(string category, decimal videoId) returns Video|error {
-        string  path = string `/categories/${category}/videos/${videoId}`;
-        Video response = check self.clientEp-> get(path, targetType = Video);
+        string resourcePath = string `/categories/${category}/videos/${videoId}`;
+        Video response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all channels
@@ -171,21 +178,20 @@ public isolated client class Client {
     # + sort - The way to sort the results. Option descriptions:  * `relevant` - Relevant sorting is available only for search queries. 
     # + return - The channels were returned. 
     remote isolated function getChannels(string? direction = (), string? filter = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Channel[]|error {
-        string  path = string `/channels`;
+        string resourcePath = string `/channels`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Channel[] response = check self.clientEp-> get(path, targetType = ChannelArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Channel[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Create a channel
     #
     # + return - The channel was created. 
-    remote isolated function createChannel(Body payload) returns Channel|error {
-        string  path = string `/channels`;
+    remote isolated function createChannel(byte[] payload) returns Channel|error {
+        string resourcePath = string `/channels`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Channel response = check self.clientEp->post(path, request, targetType=Channel);
+        request.setPayload(payload, "application/vnd.vimeo.channel+json");
+        Channel response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Get a specific channel
@@ -193,8 +199,8 @@ public isolated client class Client {
     # + channelId - The ID of the channel. 
     # + return - The channel was returned. 
     remote isolated function getChannel(decimal channelId) returns Channel|error {
-        string  path = string `/channels/${channelId}`;
-        Channel response = check self.clientEp-> get(path, targetType = Channel);
+        string resourcePath = string `/channels/${channelId}`;
+        Channel response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Delete a channel
@@ -202,20 +208,19 @@ public isolated client class Client {
     # + channelId - The ID of the channel. 
     # + return - The channel was deleted. 
     remote isolated function deleteChannel(decimal channelId) returns http:Response|error {
-        string  path = string `/channels/${channelId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/channels/${channelId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Edit a channel
     #
     # + channelId - The ID of the channel. 
     # + return - The channel was edited. 
-    remote isolated function editChannel(decimal channelId, Body1 payload) returns Channel|error {
-        string  path = string `/channels/${channelId}`;
+    remote isolated function editChannel(decimal channelId, byte[] payload) returns Channel|error {
+        string resourcePath = string `/channels/${channelId}`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Channel response = check self.clientEp->patch(path, request, targetType=Channel);
+        request.setPayload(payload, "application/vnd.vimeo.channel+json");
+        Channel response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Get all the categories in a channel
@@ -223,20 +228,20 @@ public isolated client class Client {
     # + channelId - The ID of the channel. 
     # + return - The categories were returned. 
     remote isolated function getChannelCategories(decimal channelId) returns Category[]|error {
-        string  path = string `/channels/${channelId}/categories`;
-        Category[] response = check self.clientEp-> get(path, targetType = CategoryArr);
+        string resourcePath = string `/channels/${channelId}/categories`;
+        Category[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a list of categories to a channel
     #
     # + channelId - The ID of the channel. 
     # + return - The categories were added. 
-    remote isolated function addChannelCategories(decimal channelId, Body2 payload) returns http:Response|error {
-        string  path = string `/channels/${channelId}/categories`;
+    remote isolated function addChannelCategories(decimal channelId, ChannelIdCategoriesBody payload) returns http:Response|error {
+        string resourcePath = string `/channels/${channelId}/categories`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        http:Response response = check self.clientEp->put(path, request, targetType=http:Response);
+        request.setPayload(jsonBody, "application/json");
+        http:Response response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     # Categorize a channel
@@ -245,10 +250,10 @@ public isolated client class Client {
     # + channelId - The ID of the channel. 
     # + return - The channel was categorized. 
     remote isolated function categorizeChannel(string category, decimal channelId) returns http:Response|error {
-        string  path = string `/channels/${channelId}/categories/${category}`;
+        string resourcePath = string `/channels/${channelId}/categories/${category}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Remove a category from a channel
@@ -257,8 +262,8 @@ public isolated client class Client {
     # + channelId - The ID of the channel. 
     # + return - The channel was removed. 
     remote isolated function deleteChannelCategory(string category, decimal channelId) returns http:Response|error {
-        string  path = string `/channels/${channelId}/categories/${category}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/channels/${channelId}/categories/${category}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the moderators in a channel
@@ -271,46 +276,43 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The moderators were returned. 
     remote isolated function getChannelModerators(decimal channelId, string? direction = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns User[]|error {
-        string  path = string `/channels/${channelId}/moderators`;
+        string resourcePath = string `/channels/${channelId}/moderators`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        User[] response = check self.clientEp-> get(path, targetType = UserArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        User[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a list of channel moderators
     #
     # + channelId - The ID of the channel. 
     # + return - The moderators were added. 
-    remote isolated function addChannelModerators(decimal channelId, Body3 payload) returns http:Response|error {
-        string  path = string `/channels/${channelId}/moderators`;
+    remote isolated function addChannelModerators(decimal channelId, ChannelIdModeratorsBody payload) returns http:Response|error {
+        string resourcePath = string `/channels/${channelId}/moderators`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        http:Response response = check self.clientEp->put(path, request, targetType=http:Response);
+        request.setPayload(jsonBody, "application/json");
+        http:Response response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     # Remove a list of channel moderators
     #
     # + channelId - The ID of the channel. 
     # + return - The moderators were removed. 
-    remote isolated function removeChannelModerators(decimal channelId, Body4 payload) returns User|error {
-        string  path = string `/channels/${channelId}/moderators`;
-        http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        User response = check self.clientEp->delete(path, request, targetType=User);
+    remote isolated function removeChannelModerators(decimal channelId) returns User|error {
+        string resourcePath = string `/channels/${channelId}/moderators`;
+        User response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Replace the moderators of a channel
     #
     # + channelId - The ID of the channel. 
     # + return - The moderators were replaced. 
-    remote isolated function replaceChannelModerators(decimal channelId, Body5 payload) returns User[]|error {
-        string  path = string `/channels/${channelId}/moderators`;
+    remote isolated function replaceChannelModerators(decimal channelId, ChannelIdModeratorsBody1 payload) returns User[]|error {
+        string resourcePath = string `/channels/${channelId}/moderators`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        User[] response = check self.clientEp->patch(path, request, targetType=UserArr);
+        request.setPayload(jsonBody, "application/json");
+        User[] response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Get a specific channel moderator
@@ -319,8 +321,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The moderator was returned. 
     remote isolated function getChannelModerator(decimal channelId, decimal userId) returns User|error {
-        string  path = string `/channels/${channelId}/moderators/${userId}`;
-        User response = check self.clientEp-> get(path, targetType = User);
+        string resourcePath = string `/channels/${channelId}/moderators/${userId}`;
+        User response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a specific channel moderator
@@ -328,11 +330,11 @@ public isolated client class Client {
     # + channelId - The ID of the channel. 
     # + userId - The ID of the user. 
     # + return - The authenticated user doesn't own the channel, a user is already a moderator of the channel, or you tried to add a user that the authenticated user doesn't follow. 
-    remote isolated function addChannelModerator(decimal channelId, decimal userId) returns LegacyError|error {
-        string  path = string `/channels/${channelId}/moderators/${userId}`;
+    remote isolated function addChannelModerator(decimal channelId, decimal userId) returns http:Response|error {
+        string resourcePath = string `/channels/${channelId}/moderators/${userId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        LegacyError response = check self.clientEp-> put(path, request, targetType = LegacyError);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Remove a specific channel moderator
@@ -341,8 +343,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The moderator was removed. 
     remote isolated function removeChannelModerator(decimal channelId, decimal userId) returns http:Response|error {
-        string  path = string `/channels/${channelId}/moderators/${userId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/channels/${channelId}/moderators/${userId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the users who can view a private channel
@@ -353,22 +355,21 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The users were returned. 
     remote isolated function getChannelPrivacyUsers(decimal channelId, string? direction = (), decimal? page = (), decimal? perPage = ()) returns User[]|error {
-        string  path = string `/channels/${channelId}/privacy/users`;
+        string resourcePath = string `/channels/${channelId}/privacy/users`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        User[] response = check self.clientEp-> get(path, targetType = UserArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        User[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Permit a list of users to view a private channel
     #
     # + channelId - The ID of the channel. 
     # + return - The users can now view the private channel. 
-    remote isolated function setChannelPrivacyUsers(decimal channelId, Body6 payload) returns User[]|error {
-        string  path = string `/channels/${channelId}/privacy/users`;
+    remote isolated function setChannelPrivacyUsers(decimal channelId, byte[] payload) returns User[]|error {
+        string resourcePath = string `/channels/${channelId}/privacy/users`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        User[] response = check self.clientEp->put(path, request, targetType=UserArr);
+        request.setPayload(payload, "application/vnd.vimeo.user+json");
+        User[] response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     # Permit a specific user to view a private channel
@@ -377,10 +378,10 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The user can now view the private channel. 
     remote isolated function setChannelPrivacyUser(decimal channelId, decimal userId) returns http:Response|error {
-        string  path = string `/channels/${channelId}/privacy/users/${userId}`;
+        string resourcePath = string `/channels/${channelId}/privacy/users/${userId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Restrict a user from viewing a private channel
@@ -389,8 +390,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The user can no longer view the private channel. 
     remote isolated function deleteChannelPrivacyUser(decimal channelId, decimal userId) returns http:Response|error {
-        string  path = string `/channels/${channelId}/privacy/users/${userId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/channels/${channelId}/privacy/users/${userId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the tags that have been added to a channel
@@ -398,20 +399,19 @@ public isolated client class Client {
     # + channelId - The ID of the channel. 
     # + return - The tags were returned. 
     remote isolated function getChannelTags(decimal channelId) returns Tag[]|error {
-        string  path = string `/channels/${channelId}/tags`;
-        Tag[] response = check self.clientEp-> get(path, targetType = TagArr);
+        string resourcePath = string `/channels/${channelId}/tags`;
+        Tag[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a list of tags to a channel
     #
     # + channelId - The ID of the channel. 
     # + return - The tags were added. 
-    remote isolated function addTagsToChannel(decimal channelId, Body7 payload) returns Tag[]|error {
-        string  path = string `/channels/${channelId}/tags`;
+    remote isolated function addTagsToChannel(decimal channelId, byte[] payload) returns Tag[]|error {
+        string resourcePath = string `/channels/${channelId}/tags`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Tag[] response = check self.clientEp->put(path, request, targetType=TagArr);
+        request.setPayload(payload, "application/vnd.vimeo.tag+json");
+        Tag[] response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     # Check if a tag has been added to a channel
@@ -420,8 +420,8 @@ public isolated client class Client {
     # + word - The word to use as the tag. 
     # + return - The tag has been added to the channel. 
     remote isolated function checkIfChannelHasTag(decimal channelId, string word) returns http:Response|error {
-        string  path = string `/channels/${channelId}/tags/${word}`;
-        http:Response response = check self.clientEp-> get(path, targetType = http:Response);
+        string resourcePath = string `/channels/${channelId}/tags/${word}`;
+        http:Response response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a specific tag to a channel
@@ -430,10 +430,10 @@ public isolated client class Client {
     # + word - The word to use as the tag. 
     # + return - The tag was added. 
     remote isolated function addChannelTag(decimal channelId, string word) returns http:Response|error {
-        string  path = string `/channels/${channelId}/tags/${word}`;
+        string resourcePath = string `/channels/${channelId}/tags/${word}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Remove a tag from a channel
@@ -442,25 +442,25 @@ public isolated client class Client {
     # + word - The word to use as the tag. 
     # + return - The tag was removed. 
     remote isolated function deleteTagFromChannel(decimal channelId, string word) returns http:Response|error {
-        string  path = string `/channels/${channelId}/tags/${word}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/channels/${channelId}/tags/${word}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the followers of a channel
     #
     # + channelId - The ID of the channel. 
-    # + filter - The attribute by which to filter the results. 
     # + direction - The sort direction of the results. 
+    # + filter - The attribute by which to filter the results. 
     # + page - The page number of the results to show. 
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + query - The search query to use to filter the results. 
     # + sort - The way to sort the results. 
     # + return - The followers were returned. 
     remote isolated function getChannelSubscribers(decimal channelId, string filter, string? direction = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns User[]|error {
-        string  path = string `/channels/${channelId}/users`;
+        string resourcePath = string `/channels/${channelId}/users`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        User[] response = check self.clientEp-> get(path, targetType = UserArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        User[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the videos in a channel
@@ -476,34 +476,31 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The videos were returned. 
     remote isolated function getChannelVideos(decimal channelId, string? containingUri = (), string? direction = (), string? filter = (), boolean? filterEmbeddable = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Video[]|error {
-        string  path = string `/channels/${channelId}/videos`;
+        string resourcePath = string `/channels/${channelId}/videos`;
         map<anydata> queryParam = {"containing_uri": containingUri, "direction": direction, "filter": filter, "filter_embeddable": filterEmbeddable, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a list of videos to a channel
     #
     # + channelId - The ID of the channel. 
     # + return - The videos were added. 
-    remote isolated function addVideosToChannel(decimal channelId, Body8 payload) returns http:Response|error {
-        string  path = string `/channels/${channelId}/videos`;
+    remote isolated function addVideosToChannel(decimal channelId, ChannelIdVideosBody payload) returns http:Response|error {
+        string resourcePath = string `/channels/${channelId}/videos`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        http:Response response = check self.clientEp->put(path, request, targetType=http:Response);
+        request.setPayload(jsonBody, "application/json");
+        http:Response response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     # Remove a list of videos from a channel
     #
     # + channelId - The ID of the channel. 
     # + return - The videos were removed. 
-    remote isolated function removeVideosFromChannel(decimal channelId, Body9 payload) returns Video|error {
-        string  path = string `/channels/${channelId}/videos`;
-        http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Video response = check self.clientEp->delete(path, request, targetType=Video);
+    remote isolated function removeVideosFromChannel(decimal channelId) returns Video|error {
+        string resourcePath = string `/channels/${channelId}/videos`;
+        Video response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get a specific video in a channel
@@ -512,8 +509,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was returned. 
     remote isolated function getChannelVideo(decimal channelId, decimal videoId) returns Video|error {
-        string  path = string `/channels/${channelId}/videos/${videoId}`;
-        Video response = check self.clientEp-> get(path, targetType = Video);
+        string resourcePath = string `/channels/${channelId}/videos/${videoId}`;
+        Video response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a specific video to a channel
@@ -522,10 +519,10 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was added. 
     remote isolated function addVideoToChannel(decimal channelId, decimal videoId) returns http:Response|error {
-        string  path = string `/channels/${channelId}/videos/${videoId}`;
+        string resourcePath = string `/channels/${channelId}/videos/${videoId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Remove a specific video from a channel
@@ -534,8 +531,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was removed. 
     remote isolated function deleteVideoFromChannel(decimal channelId, decimal videoId) returns http:Response|error {
-        string  path = string `/channels/${channelId}/videos/${videoId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/channels/${channelId}/videos/${videoId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the comments on a video
@@ -547,10 +544,10 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The comments were returned. 
     remote isolated function getCommentsAlt1(decimal channelId, decimal videoId, string? direction = (), decimal? page = (), decimal? perPage = ()) returns Comment[]|error {
-        string  path = string `/channels/${channelId}/videos/${videoId}/comments`;
+        string resourcePath = string `/channels/${channelId}/videos/${videoId}/comments`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        Comment[] response = check self.clientEp-> get(path, targetType = CommentArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Comment[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a comment to a video
@@ -558,12 +555,11 @@ public isolated client class Client {
     # + channelId - The ID of the channel. 
     # + videoId - The ID of the video. 
     # + return - The comment was added. 
-    remote isolated function createCommentAlt1(decimal channelId, decimal videoId, Body10 payload) returns Comment|error {
-        string  path = string `/channels/${channelId}/videos/${videoId}/comments`;
+    remote isolated function createCommentAlt1(decimal channelId, decimal videoId, byte[] payload) returns Comment|error {
+        string resourcePath = string `/channels/${channelId}/videos/${videoId}/comments`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Comment response = check self.clientEp->post(path, request, targetType=Comment);
+        request.setPayload(payload, "application/vnd.vimeo.comment+json");
+        Comment response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Get all the credited users in a video
@@ -577,10 +573,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The users were returned. 
     remote isolated function getVideoCreditsAlt1(decimal channelId, decimal videoId, string? direction = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Credit[]|error {
-        string  path = string `/channels/${channelId}/videos/${videoId}/credits`;
+        string resourcePath = string `/channels/${channelId}/videos/${videoId}/credits`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Credit[] response = check self.clientEp-> get(path, targetType = CreditArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Credit[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Credit a user in a video
@@ -588,12 +584,11 @@ public isolated client class Client {
     # + channelId - The ID of the channel. 
     # + videoId - The ID of the video. 
     # + return - The credit was added. 
-    remote isolated function addVideoCreditAlt1(decimal channelId, decimal videoId, Body11 payload) returns Credit|error {
-        string  path = string `/channels/${channelId}/videos/${videoId}/credits`;
+    remote isolated function addVideoCreditAlt1(decimal channelId, decimal videoId, byte[] payload) returns Credit|error {
+        string resourcePath = string `/channels/${channelId}/videos/${videoId}/credits`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Credit response = check self.clientEp->post(path, request, targetType=Credit);
+        request.setPayload(payload, "application/vnd.vimeo.credit+json");
+        Credit response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Get all the users who have liked a video
@@ -606,10 +601,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The users were returned. 
     remote isolated function getVideoLikesAlt1(decimal channelId, decimal videoId, string? direction = (), decimal? page = (), decimal? perPage = (), string? sort = ()) returns User[]|error {
-        string  path = string `/channels/${channelId}/videos/${videoId}/likes`;
+        string resourcePath = string `/channels/${channelId}/videos/${videoId}/likes`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        User[] response = check self.clientEp-> get(path, targetType = UserArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        User[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the thumbnails of a video
@@ -620,10 +615,10 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The thumbnails were returned. 
     remote isolated function getVideoThumbnailsAlt1(decimal channelId, decimal videoId, decimal? page = (), decimal? perPage = ()) returns Picture[]|error {
-        string  path = string `/channels/${channelId}/videos/${videoId}/pictures`;
+        string resourcePath = string `/channels/${channelId}/videos/${videoId}/pictures`;
         map<anydata> queryParam = {"page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        Picture[] response = check self.clientEp-> get(path, targetType = PictureArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Picture[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a video thumbnail
@@ -631,12 +626,11 @@ public isolated client class Client {
     # + channelId - The ID of the channel. 
     # + videoId - The ID of the video. 
     # + return - The thumbnail was created. 
-    remote isolated function createVideoThumbnailAlt1(decimal channelId, decimal videoId, Body12 payload) returns Picture|error {
-        string  path = string `/channels/${channelId}/videos/${videoId}/pictures`;
+    remote isolated function createVideoThumbnailAlt1(decimal channelId, decimal videoId, byte[] payload) returns Picture|error {
+        string resourcePath = string `/channels/${channelId}/videos/${videoId}/pictures`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Picture response = check self.clientEp->post(path, request, targetType=Picture);
+        request.setPayload(payload, "application/vnd.vimeo.picture+json");
+        Picture response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Get all the users who can view a user's private videos by default
@@ -647,10 +641,10 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The users were returned. 
     remote isolated function getVideoPrivacyUsersAlt1(decimal channelId, decimal videoId, decimal? page = (), decimal? perPage = ()) returns User[]|error {
-        string  path = string `/channels/${channelId}/videos/${videoId}/privacy/users`;
+        string resourcePath = string `/channels/${channelId}/videos/${videoId}/privacy/users`;
         map<anydata> queryParam = {"page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        User[] response = check self.clientEp-> get(path, targetType = UserArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        User[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Permit a list of users to view a private video
@@ -659,10 +653,10 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The users can now view the private video. 
     remote isolated function addVideoPrivacyUsersAlt1(decimal channelId, decimal videoId) returns User[]|error {
-        string  path = string `/channels/${channelId}/videos/${videoId}/privacy/users`;
+        string resourcePath = string `/channels/${channelId}/videos/${videoId}/privacy/users`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        User[] response = check self.clientEp-> put(path, request, targetType = UserArr);
+        User[] response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Get all the text tracks of a video
@@ -671,8 +665,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The text tracks were returned. 
     remote isolated function getTextTracksAlt1(decimal channelId, decimal videoId) returns TextTrack[]|error {
-        string  path = string `/channels/${channelId}/videos/${videoId}/texttracks`;
-        TextTrack[] response = check self.clientEp-> get(path, targetType = TextTrackArr);
+        string resourcePath = string `/channels/${channelId}/videos/${videoId}/texttracks`;
+        TextTrack[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a text track to a video
@@ -680,28 +674,27 @@ public isolated client class Client {
     # + channelId - The ID of the channel. 
     # + videoId - The ID of the video. 
     # + return - The text track was added. 
-    remote isolated function createTextTrackAlt1(decimal channelId, decimal videoId, Body13 payload) returns TextTrack|error {
-        string  path = string `/channels/${channelId}/videos/${videoId}/texttracks`;
+    remote isolated function createTextTrackAlt1(decimal channelId, decimal videoId, byte[] payload) returns TextTrack|error {
+        string resourcePath = string `/channels/${channelId}/videos/${videoId}/texttracks`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        TextTrack response = check self.clientEp->post(path, request, targetType=TextTrack);
+        request.setPayload(payload, "application/vnd.vimeo.video.texttrack+json");
+        TextTrack response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Get all content ratings
     #
     # + return - The content ratings were returned. 
     remote isolated function getContentRatings() returns ContentRating[]|error {
-        string  path = string `/contentratings`;
-        ContentRating[] response = check self.clientEp-> get(path, targetType = ContentRatingArr);
+        string resourcePath = string `/contentratings`;
+        ContentRating[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all Creative Commons licenses
     #
     # + return - The Creative Commons licenses were returned. 
     remote isolated function getCcLicenses() returns CreativeCommons[]|error {
-        string  path = string `/creativecommons`;
-        CreativeCommons[] response = check self.clientEp-> get(path, targetType = CreativeCommonsArr);
+        string resourcePath = string `/creativecommons`;
+        CreativeCommons[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all groups
@@ -714,21 +707,20 @@ public isolated client class Client {
     # + sort - The way to sort the results. Option descriptions:  * `relevant` - Relevant sorting is available only for search queries. 
     # + return - The groups were returned. 
     remote isolated function getGroups(string? direction = (), string? filter = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Group[]|error {
-        string  path = string `/groups`;
+        string resourcePath = string `/groups`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Group[] response = check self.clientEp-> get(path, targetType = GroupArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Group[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Create a group
     #
     # + return - The group was created. 
-    remote isolated function createGroup(Body14 payload) returns Group|error {
-        string  path = string `/groups`;
+    remote isolated function createGroup(byte[] payload) returns Group|error {
+        string resourcePath = string `/groups`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Group response = check self.clientEp->post(path, request, targetType=Group);
+        request.setPayload(payload, "application/vnd.vimeo.group+json");
+        Group response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Get a specific group
@@ -736,8 +728,8 @@ public isolated client class Client {
     # + groupId - The ID of the group. 
     # + return - The group was returned. 
     remote isolated function getGroup(decimal groupId) returns Group|error {
-        string  path = string `/groups/${groupId}`;
-        Group response = check self.clientEp-> get(path, targetType = Group);
+        string resourcePath = string `/groups/${groupId}`;
+        Group response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Delete a group
@@ -745,8 +737,8 @@ public isolated client class Client {
     # + groupId - The ID of the group. 
     # + return - The group was deleted. 
     remote isolated function deleteGroup(decimal groupId) returns http:Response|error {
-        string  path = string `/groups/${groupId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/groups/${groupId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the members of a group
@@ -760,10 +752,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The members were returned. 
     remote isolated function getGroupMembers(decimal groupId, string? direction = (), string? filter = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns User[]|error {
-        string  path = string `/groups/${groupId}/users`;
+        string resourcePath = string `/groups/${groupId}/users`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        User[] response = check self.clientEp-> get(path, targetType = UserArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        User[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the videos in a group
@@ -778,10 +770,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The videos were returned. 
     remote isolated function getGroupVideos(decimal groupId, string? direction = (), string? filter = (), boolean? filterEmbeddable = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Video[]|error {
-        string  path = string `/groups/${groupId}/videos`;
+        string resourcePath = string `/groups/${groupId}/videos`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "filter_embeddable": filterEmbeddable, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get a specific video in a group
@@ -790,8 +782,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was returned. 
     remote isolated function getGroupVideo(decimal groupId, decimal videoId) returns Video|error {
-        string  path = string `/groups/${groupId}/videos/${videoId}`;
-        Video response = check self.clientEp-> get(path, targetType = Video);
+        string resourcePath = string `/groups/${groupId}/videos/${videoId}`;
+        Video response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a video to a group
@@ -799,11 +791,11 @@ public isolated client class Client {
     # + groupId - The ID of the group. 
     # + videoId - The ID of the video. 
     # + return - The video was added. 
-    remote isolated function addVideoToGroup(decimal groupId, decimal videoId) returns Video|error {
-        string  path = string `/groups/${groupId}/videos/${videoId}`;
+    remote isolated function addVideoToGroup(decimal groupId, decimal videoId) returns Video|error? {
+        string resourcePath = string `/groups/${groupId}/videos/${videoId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        Video response = check self.clientEp-> put(path, request, targetType = Video);
+        Video? response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Remove a video from a group
@@ -812,8 +804,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was deleted. 
     remote isolated function deleteVideoFromGroup(decimal groupId, decimal videoId) returns http:Response|error {
-        string  path = string `/groups/${groupId}/videos/${videoId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/groups/${groupId}/videos/${videoId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all languages
@@ -821,29 +813,28 @@ public isolated client class Client {
     # + filter - The attribute by which to filter the results. Option descriptions:  * `texttracks` - Only return text track supported languages 
     # + return - The languages were returned. 
     remote isolated function getLanguages(string? filter = ()) returns Language[]|error {
-        string  path = string `/languages`;
+        string resourcePath = string `/languages`;
         map<anydata> queryParam = {"filter": filter};
-        path = path + check getPathForQueryParam(queryParam);
-        Language[] response = check self.clientEp-> get(path, targetType = LanguageArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Language[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get a user
     #
     # + return - The user was returned. 
     remote isolated function getUserAlt1() returns User|error {
-        string  path = string `/me`;
-        User response = check self.clientEp-> get(path, targetType = User);
+        string resourcePath = string `/me`;
+        User response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Edit a user
     #
     # + return - The user was edited. 
-    remote isolated function editUserAlt1(Body15 payload) returns User|error {
-        string  path = string `/me`;
+    remote isolated function editUserAlt1(byte[] payload) returns User|error {
+        string resourcePath = string `/me`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        User response = check self.clientEp->patch(path, request, targetType=User);
+        request.setPayload(payload, "application/vnd.vimeo.user+json");
+        User response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Get all the albums that belong to a user
@@ -855,21 +846,20 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The albums were returned. 
     remote isolated function getAlbumsAlt1(string? direction = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Album[]|error {
-        string  path = string `/me/albums`;
+        string resourcePath = string `/me/albums`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Album[] response = check self.clientEp-> get(path, targetType = AlbumArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Album[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Create an album
     #
     # + return - The album was created. 
-    remote isolated function createAlbumAlt1(Body16 payload) returns Album|error {
-        string  path = string `/me/albums`;
+    remote isolated function createAlbumAlt1(byte[] payload) returns Album|error {
+        string resourcePath = string `/me/albums`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Album response = check self.clientEp->post(path, request, targetType=Album);
+        request.setPayload(payload, "application/vnd.vimeo.album+json");
+        Album response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Get a specific album
@@ -877,8 +867,8 @@ public isolated client class Client {
     # + albumId - The ID of the album. 
     # + return - The album was returned. 
     remote isolated function getAlbumAlt1(decimal albumId) returns Album|error {
-        string  path = string `/me/albums/${albumId}`;
-        Album response = check self.clientEp-> get(path, targetType = Album);
+        string resourcePath = string `/me/albums/${albumId}`;
+        Album response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Delete an album
@@ -886,20 +876,19 @@ public isolated client class Client {
     # + albumId - The ID of the album. 
     # + return - The album was deleted. 
     remote isolated function deleteAlbumAlt1(decimal albumId) returns http:Response|error {
-        string  path = string `/me/albums/${albumId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/me/albums/${albumId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Edit an album
     #
     # + albumId - The ID of the album. 
     # + return - The album was edited. 
-    remote isolated function editAlbumAlt1(decimal albumId, Body17 payload) returns Album|error {
-        string  path = string `/me/albums/${albumId}`;
+    remote isolated function editAlbumAlt1(decimal albumId, byte[] payload) returns Album|error {
+        string resourcePath = string `/me/albums/${albumId}`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Album response = check self.clientEp->patch(path, request, targetType=Album);
+        request.setPayload(payload, "application/vnd.vimeo.album+json");
+        Album response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Get all the videos in an album
@@ -917,22 +906,22 @@ public isolated client class Client {
     # + weakSearch - Whether to include private videos in the search. Please note that a separate search service provides this functionality. The service performs a partial text search on the video's name. 
     # + return - The videos were returned. 
     remote isolated function getAlbumVideosAlt1(decimal albumId, string? containingUri = (), string? direction = (), string? filter = (), boolean? filterEmbeddable = (), decimal? page = (), string? password = (), decimal? perPage = (), string? query = (), string? sort = (), boolean? weakSearch = ()) returns Video[]|error {
-        string  path = string `/me/albums/${albumId}/videos`;
+        string resourcePath = string `/me/albums/${albumId}/videos`;
         map<anydata> queryParam = {"containing_uri": containingUri, "direction": direction, "filter": filter, "filter_embeddable": filterEmbeddable, "page": page, "password": password, "per_page": perPage, "query": query, "sort": sort, "weak_search": weakSearch};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Replace all the videos in an album
     #
     # + albumId - The ID of the album. 
     # + return - The videos were added. 
-    remote isolated function replaceVideosInAlbumAlt1(decimal albumId, Body18 payload) returns http:Response|error {
-        string  path = string `/me/albums/${albumId}/videos`;
+    remote isolated function replaceVideosInAlbumAlt1(decimal albumId, AlbumIdVideosBody payload) returns http:Response|error {
+        string resourcePath = string `/me/albums/${albumId}/videos`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        http:Response response = check self.clientEp->put(path, request, targetType=http:Response);
+        request.setPayload(jsonBody, "application/json");
+        http:Response response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     # Get a specific video in an album
@@ -942,10 +931,10 @@ public isolated client class Client {
     # + password - The password of the album. 
     # + return - The video was returned. 
     remote isolated function getAlbumVideoAlt1(decimal albumId, decimal videoId, string? password = ()) returns Video|error {
-        string  path = string `/me/albums/${albumId}/videos/${videoId}`;
+        string resourcePath = string `/me/albums/${albumId}/videos/${videoId}`;
         map<anydata> queryParam = {"password": password};
-        path = path + check getPathForQueryParam(queryParam);
-        Video response = check self.clientEp-> get(path, targetType = Video);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a specific video to an album
@@ -954,10 +943,10 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was added. 
     remote isolated function addVideoToAlbumAlt1(decimal albumId, decimal videoId) returns http:Response|error {
-        string  path = string `/me/albums/${albumId}/videos/${videoId}`;
+        string resourcePath = string `/me/albums/${albumId}/videos/${videoId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Remove a video from an album
@@ -966,8 +955,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was removed. 
     remote isolated function removeVideoFromAlbumAlt1(decimal albumId, decimal videoId) returns http:Response|error {
-        string  path = string `/me/albums/${albumId}/videos/${videoId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/me/albums/${albumId}/videos/${videoId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Set a video as the album thumbnail
@@ -975,12 +964,12 @@ public isolated client class Client {
     # + albumId - The ID of the album. 
     # + videoId - The ID of the video. 
     # + return - The album was updated with a new thumbnail. 
-    remote isolated function setVideoAsAlbumThumbnailAlt1(decimal albumId, decimal videoId, Body19 payload) returns Album|error {
-        string  path = string `/me/albums/${albumId}/videos/${videoId}/set_album_thumbnail`;
+    remote isolated function setVideoAsAlbumThumbnailAlt1(decimal albumId, decimal videoId, VideoIdSetAlbumThumbnailBody payload) returns Album|error {
+        string resourcePath = string `/me/albums/${albumId}/videos/${videoId}/set_album_thumbnail`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Album response = check self.clientEp->post(path, request, targetType=Album);
+        request.setPayload(jsonBody, "application/json");
+        Album response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Get all the videos in which a user appears
@@ -994,10 +983,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The videos were returned. 
     remote isolated function getAppearancesAlt1(string? direction = (), string? filter = (), boolean? filterEmbeddable = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Video[]|error {
-        string  path = string `/me/appearances`;
+        string resourcePath = string `/me/appearances`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "filter_embeddable": filterEmbeddable, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the categories that a user follows
@@ -1008,10 +997,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The categories were returned. 
     remote isolated function getCategorySubscriptionsAlt1(string? direction = (), decimal? page = (), decimal? perPage = (), string? sort = ()) returns Category[]|error {
-        string  path = string `/me/categories`;
+        string resourcePath = string `/me/categories`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Category[] response = check self.clientEp-> get(path, targetType = CategoryArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Category[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Check if a user follows a category
@@ -1019,8 +1008,8 @@ public isolated client class Client {
     # + category - The name of the category. 
     # + return - The user is following the category. 
     remote isolated function checkIfUserSubscribedToCategoryAlt1(string category) returns http:Response|error {
-        string  path = string `/me/categories/${category}`;
-        http:Response response = check self.clientEp-> get(path, targetType = http:Response);
+        string resourcePath = string `/me/categories/${category}`;
+        http:Response response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Subscribe a user to a single category
@@ -1028,10 +1017,10 @@ public isolated client class Client {
     # + category - The name of the category. 
     # + return - The user was subscribed. 
     remote isolated function subscribeToCategoryAlt1(decimal category) returns http:Response|error {
-        string  path = string `/me/categories/${category}`;
+        string resourcePath = string `/me/categories/${category}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Unsubscribe a user from a category
@@ -1039,8 +1028,8 @@ public isolated client class Client {
     # + category - The name of the category. 
     # + return - The user was unsubscribed. 
     remote isolated function unsubscribeFromCategoryAlt1(string category) returns http:Response|error {
-        string  path = string `/me/categories/${category}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/me/categories/${category}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the channels to which a user subscribes
@@ -1053,10 +1042,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The channels were returned. 
     remote isolated function getChannelSubscriptionsAlt1(string? direction = (), string? filter = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Channel[]|error {
-        string  path = string `/me/channels`;
+        string resourcePath = string `/me/channels`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Channel[] response = check self.clientEp-> get(path, targetType = ChannelArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Channel[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Check if a user follows a channel
@@ -1064,8 +1053,8 @@ public isolated client class Client {
     # + channelId - The ID of the channel. 
     # + return - The user follows the channel. 
     remote isolated function checkIfUserSubscribedToChannelAlt1(decimal channelId) returns http:Response|error {
-        string  path = string `/me/channels/${channelId}`;
-        http:Response response = check self.clientEp-> get(path, targetType = http:Response);
+        string resourcePath = string `/me/channels/${channelId}`;
+        http:Response response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Subscribe a user to a specific channel
@@ -1073,10 +1062,10 @@ public isolated client class Client {
     # + channelId - The ID of the channel. 
     # + return - The user is now a follower of the channel. 
     remote isolated function subscribeToChannelAlt1(decimal channelId) returns http:Response|error {
-        string  path = string `/me/channels/${channelId}`;
+        string resourcePath = string `/me/channels/${channelId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Unsubscribe a user from a specific channel
@@ -1084,26 +1073,26 @@ public isolated client class Client {
     # + channelId - The ID of the channel. 
     # + return - The user is no longer a follower of the channel. 
     remote isolated function unsubscribeFromChannelAlt1(decimal channelId) returns http:Response|error {
-        string  path = string `/me/channels/${channelId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/me/channels/${channelId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the custom logos that belong to a user
     #
     # + return - The custom logos were returned. 
     remote isolated function getCustomLogosAlt1() returns Picture[]|error {
-        string  path = string `/me/customlogos`;
-        Picture[] response = check self.clientEp-> get(path, targetType = PictureArr);
+        string resourcePath = string `/me/customlogos`;
+        Picture[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a custom logo
     #
     # + return - The custom logo was created. 
     remote isolated function createCustomLogoAlt1() returns Picture|error {
-        string  path = string `/me/customlogos`;
+        string resourcePath = string `/me/customlogos`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        Picture response = check self.clientEp-> post(path, request, targetType = Picture);
+        Picture response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     # Get a specific custom logo
@@ -1111,8 +1100,8 @@ public isolated client class Client {
     # + logoId - The ID of the custom logo. 
     # + return - The custom logo was returned. 
     remote isolated function getCustomLogoAlt1(decimal logoId) returns Picture|error {
-        string  path = string `/me/customlogos/${logoId}`;
-        Picture response = check self.clientEp-> get(path, targetType = Picture);
+        string resourcePath = string `/me/customlogos/${logoId}`;
+        Picture response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all videos in a user's feed
@@ -1123,10 +1112,10 @@ public isolated client class Client {
     # + 'type - The feed type. 
     # + return - The videos were returned. 
     remote isolated function getFeedAlt1(string? offset = (), decimal? page = (), decimal? perPage = (), string? 'type = ()) returns Activity31[]|error {
-        string  path = string `/me/feed`;
+        string resourcePath = string `/me/feed`;
         map<anydata> queryParam = {"offset": offset, "page": page, "per_page": perPage, "type": 'type};
-        path = path + check getPathForQueryParam(queryParam);
-        Activity31[] response = check self.clientEp-> get(path, targetType = Activity31Arr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Activity31[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the followers of a user
@@ -1138,10 +1127,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The user's followers were returned. 
     remote isolated function getFollowersAlt1(string? direction = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns User[]|error {
-        string  path = string `/me/followers`;
+        string resourcePath = string `/me/followers`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        User[] response = check self.clientEp-> get(path, targetType = UserArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        User[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the users that a user is following
@@ -1154,21 +1143,21 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The followed users were returned. 
     remote isolated function getUserFollowingAlt1(string? direction = (), string? filter = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns User[]|error {
-        string  path = string `/me/following`;
+        string resourcePath = string `/me/following`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        User[] response = check self.clientEp-> get(path, targetType = UserArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        User[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Follow a list of users
     #
     # + return - The users were followed. 
-    remote isolated function followUsersAlt1(Body20 payload) returns http:Response|error {
-        string  path = string `/me/following`;
+    remote isolated function followUsersAlt1(MeFollowingBody payload) returns http:Response|error {
+        string resourcePath = string `/me/following`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        http:Response response = check self.clientEp->post(path, request, targetType=http:Response);
+        request.setPayload(jsonBody, "application/json");
+        http:Response response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Check if a user is following another user
@@ -1176,8 +1165,8 @@ public isolated client class Client {
     # + followUserId - The ID of the following user. 
     # + return - The authenticated user follows the user in question. 
     remote isolated function checkIfUserIsFollowingAlt1(decimal followUserId) returns http:Response|error {
-        string  path = string `/me/following/${followUserId}`;
-        http:Response response = check self.clientEp-> get(path, targetType = http:Response);
+        string resourcePath = string `/me/following/${followUserId}`;
+        http:Response response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Follow a specific user
@@ -1185,10 +1174,10 @@ public isolated client class Client {
     # + followUserId - The ID of the following user. 
     # + return - The user was followed. 
     remote isolated function followUserAlt1(decimal followUserId) returns http:Response|error {
-        string  path = string `/me/following/${followUserId}`;
+        string resourcePath = string `/me/following/${followUserId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Unfollow a user
@@ -1196,8 +1185,8 @@ public isolated client class Client {
     # + followUserId - The ID of the following user. 
     # + return - The user was unfollowed. 
     remote isolated function unfollowUserAlt1(decimal followUserId) returns http:Response|error {
-        string  path = string `/me/following/${followUserId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/me/following/${followUserId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the groups that a user has joined
@@ -1210,10 +1199,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The groups were returned. 
     remote isolated function getUserGroupsAlt1(string? direction = (), string? filter = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Group[]|error {
-        string  path = string `/me/groups`;
+        string resourcePath = string `/me/groups`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Group[] response = check self.clientEp-> get(path, targetType = GroupArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Group[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Check if a user has joined a group
@@ -1221,8 +1210,8 @@ public isolated client class Client {
     # + groupId - The ID of the group. 
     # + return - The user has joined the group. 
     remote isolated function checkIfUserJoinedGroupAlt1(decimal groupId) returns http:Response|error {
-        string  path = string `/me/groups/${groupId}`;
-        http:Response response = check self.clientEp-> get(path, targetType = http:Response);
+        string resourcePath = string `/me/groups/${groupId}`;
+        http:Response response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a user to a group
@@ -1230,10 +1219,10 @@ public isolated client class Client {
     # + groupId - The ID of the group. 
     # + return - The user joined the group. 
     remote isolated function joinGroupAlt1(decimal groupId) returns http:Response|error {
-        string  path = string `/me/groups/${groupId}`;
+        string resourcePath = string `/me/groups/${groupId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Remove a user from a group
@@ -1241,8 +1230,8 @@ public isolated client class Client {
     # + groupId - The ID of the group. 
     # + return - The user left the group. 
     remote isolated function leaveGroupAlt1(decimal groupId) returns http:Response|error {
-        string  path = string `/me/groups/${groupId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/me/groups/${groupId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the videos that a user has liked
@@ -1255,10 +1244,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The videos were returned. 
     remote isolated function getLikesAlt1(string? filter = (), boolean? filterEmbeddable = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Video[]|error {
-        string  path = string `/me/likes`;
+        string resourcePath = string `/me/likes`;
         map<anydata> queryParam = {"filter": filter, "filter_embeddable": filterEmbeddable, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Check if a user has liked a video
@@ -1266,8 +1255,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The user has liked the video. 
     remote isolated function checkIfUserLikedVideoAlt1(decimal videoId) returns http:Response|error {
-        string  path = string `/me/likes/${videoId}`;
-        http:Response response = check self.clientEp-> get(path, targetType = http:Response);
+        string resourcePath = string `/me/likes/${videoId}`;
+        http:Response response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Cause a user to like a video
@@ -1275,10 +1264,10 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was liked. 
     remote isolated function likeVideoAlt1(decimal videoId) returns http:Response|error {
-        string  path = string `/me/likes/${videoId}`;
+        string resourcePath = string `/me/likes/${videoId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Cause a user to unlike a video
@@ -1286,8 +1275,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was unliked. 
     remote isolated function unlikeVideoAlt1(decimal videoId) returns http:Response|error {
-        string  path = string `/me/likes/${videoId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/me/likes/${videoId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the On Demand pages of a user
@@ -1299,21 +1288,21 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The On Demand pages were returned. 
     remote isolated function getUserVodsAlt1(string? direction = (), string? filter = (), decimal? page = (), decimal? perPage = (), string? sort = ()) returns OnDemandPage[]|error {
-        string  path = string `/me/ondemand/pages`;
+        string resourcePath = string `/me/ondemand/pages`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "page": page, "per_page": perPage, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        OnDemandPage[] response = check self.clientEp-> get(path, targetType = OnDemandPageArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        OnDemandPage[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Create an On Demand page
     #
     # + return - The On Demand page was created. 
-    remote isolated function createVodAlt1(Body21 payload) returns OnDemandPage|error {
-        string  path = string `/me/ondemand/pages`;
+    remote isolated function createVodAlt1(OndemandPagesBody payload) returns OnDemandPage|error {
+        string resourcePath = string `/me/ondemand/pages`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        OnDemandPage response = check self.clientEp->post(path, request, targetType=OnDemandPage);
+        request.setPayload(jsonBody, "application/json");
+        OnDemandPage response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Get all the On Demand purchases and rentals that a user has made
@@ -1325,10 +1314,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The purchases and rentals were returned. 
     remote isolated function getVodPurchases(string? direction = (), string? filter = (), decimal? page = (), decimal? perPage = (), string? sort = ()) returns OnDemandPage[]|error {
-        string  path = string `/me/ondemand/purchases`;
+        string resourcePath = string `/me/ondemand/purchases`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "page": page, "per_page": perPage, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        OnDemandPage[] response = check self.clientEp-> get(path, targetType = OnDemandPageArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        OnDemandPage[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Check if a user has made a purchase or rental from an On Demand page
@@ -1336,8 +1325,8 @@ public isolated client class Client {
     # + ondemandId - The ID of the On Demand. 
     # + return - You have purchased the On Demand page. 
     remote isolated function checkIfVodWasPurchasedAlt1(decimal ondemandId) returns OnDemandPage|error {
-        string  path = string `/me/ondemand/purchases/${ondemandId}`;
-        OnDemandPage response = check self.clientEp-> get(path, targetType = OnDemandPage);
+        string resourcePath = string `/me/ondemand/purchases/${ondemandId}`;
+        OnDemandPage response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the pictures that belong to a user
@@ -1346,20 +1335,20 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The pictures were returned. 
     remote isolated function getPicturesAlt1(decimal? page = (), decimal? perPage = ()) returns Picture[]|error {
-        string  path = string `/me/pictures`;
+        string resourcePath = string `/me/pictures`;
         map<anydata> queryParam = {"page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        Picture[] response = check self.clientEp-> get(path, targetType = PictureArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Picture[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a user picture
     #
     # + return - The user picture was created. 
     remote isolated function createPictureAlt1() returns Picture|error {
-        string  path = string `/me/pictures`;
+        string resourcePath = string `/me/pictures`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        Picture response = check self.clientEp-> post(path, request, targetType = Picture);
+        Picture response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     # Get a specific user picture
@@ -1367,8 +1356,8 @@ public isolated client class Client {
     # + portraitsetId - The ID of the picture. 
     # + return - The picture was returned. 
     remote isolated function getPictureAlt1(decimal portraitsetId) returns Picture|error {
-        string  path = string `/me/pictures/${portraitsetId}`;
-        Picture response = check self.clientEp-> get(path, targetType = Picture);
+        string resourcePath = string `/me/pictures/${portraitsetId}`;
+        Picture response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Delete a user picture
@@ -1376,20 +1365,19 @@ public isolated client class Client {
     # + portraitsetId - The ID of the picture. 
     # + return - The picture was deleted. 
     remote isolated function deletePictureAlt1(decimal portraitsetId) returns http:Response|error {
-        string  path = string `/me/pictures/${portraitsetId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/me/pictures/${portraitsetId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Edit a user picture
     #
     # + portraitsetId - The ID of the picture. 
     # + return - The picture was edited. 
-    remote isolated function editPictureAlt1(decimal portraitsetId, Body22 payload) returns Picture|error {
-        string  path = string `/me/pictures/${portraitsetId}`;
+    remote isolated function editPictureAlt1(decimal portraitsetId, byte[] payload) returns Picture|error {
+        string resourcePath = string `/me/pictures/${portraitsetId}`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Picture response = check self.clientEp->patch(path, request, targetType=Picture);
+        request.setPayload(payload, "application/vnd.vimeo.picture+json");
+        Picture response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Get all the portfolios that belong to a user
@@ -1401,10 +1389,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The portfolios were returned. 
     remote isolated function getPortfoliosAlt1(string? direction = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Portfolio[]|error {
-        string  path = string `/me/portfolios`;
+        string resourcePath = string `/me/portfolios`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Portfolio[] response = check self.clientEp-> get(path, targetType = PortfolioArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Portfolio[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get a specific portfolio
@@ -1412,8 +1400,8 @@ public isolated client class Client {
     # + portfolioId - The ID of the portfolio. 
     # + return - The portfolio was returned. 
     remote isolated function getPortfolioAlt1(decimal portfolioId) returns Portfolio|error {
-        string  path = string `/me/portfolios/${portfolioId}`;
-        Portfolio response = check self.clientEp-> get(path, targetType = Portfolio);
+        string resourcePath = string `/me/portfolios/${portfolioId}`;
+        Portfolio response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the videos in a portfolio
@@ -1427,10 +1415,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. Option descriptions:  * `default` - This will sort to the default sort set on the portfolio. 
     # + return - The videos were returned. 
     remote isolated function getPortfolioVideosAlt1(decimal portfolioId, string? containingUri = (), string? filter = (), boolean? filterEmbeddable = (), decimal? page = (), decimal? perPage = (), string? sort = ()) returns Video[]|error {
-        string  path = string `/me/portfolios/${portfolioId}/videos`;
+        string resourcePath = string `/me/portfolios/${portfolioId}/videos`;
         map<anydata> queryParam = {"containing_uri": containingUri, "filter": filter, "filter_embeddable": filterEmbeddable, "page": page, "per_page": perPage, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get a specific video in a portfolio
@@ -1439,8 +1427,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was returned. 
     remote isolated function getPortfolioVideoAlt1(decimal portfolioId, decimal videoId) returns Video|error {
-        string  path = string `/me/portfolios/${portfolioId}/videos/${videoId}`;
-        Video response = check self.clientEp-> get(path, targetType = Video);
+        string resourcePath = string `/me/portfolios/${portfolioId}/videos/${videoId}`;
+        Video response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a video to a portfolio
@@ -1449,10 +1437,10 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was added. 
     remote isolated function addVideoToPortfolioAlt1(decimal portfolioId, decimal videoId) returns http:Response|error {
-        string  path = string `/me/portfolios/${portfolioId}/videos/${videoId}`;
+        string resourcePath = string `/me/portfolios/${portfolioId}/videos/${videoId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Remove a video from a portfolio
@@ -1461,8 +1449,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was deleted. 
     remote isolated function deleteVideoFromPortfolioAlt1(decimal portfolioId, decimal videoId) returns http:Response|error {
-        string  path = string `/me/portfolios/${portfolioId}/videos/${videoId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/me/portfolios/${portfolioId}/videos/${videoId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the embed presets that a user has created
@@ -1471,10 +1459,10 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The embed presets were returned. 
     remote isolated function getEmbedPresetsAlt1(decimal? page = (), decimal? perPage = ()) returns Presets[]|error {
-        string  path = string `/me/presets`;
+        string resourcePath = string `/me/presets`;
         map<anydata> queryParam = {"page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        Presets[] response = check self.clientEp-> get(path, targetType = PresetsArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Presets[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get a specific embed preset
@@ -1482,20 +1470,19 @@ public isolated client class Client {
     # + presetId - The ID of the preset. 
     # + return - The embed preset was returned. 
     remote isolated function getEmbedPresetAlt1(decimal presetId) returns Presets|error {
-        string  path = string `/me/presets/${presetId}`;
-        Presets response = check self.clientEp-> get(path, targetType = Presets);
+        string resourcePath = string `/me/presets/${presetId}`;
+        Presets response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Edit an embed preset
     #
     # + presetId - The ID of the preset. 
     # + return - The embed preset was edited. 
-    remote isolated function editEmbedPresetAlt1(decimal presetId, Body23 payload) returns Presets|error {
-        string  path = string `/me/presets/${presetId}`;
+    remote isolated function editEmbedPresetAlt1(decimal presetId, byte[] payload) returns Presets|error {
+        string resourcePath = string `/me/presets/${presetId}`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Presets response = check self.clientEp->patch(path, request, targetType=Presets);
+        request.setPayload(payload, "application/vnd.vimeo.preset+json");
+        Presets response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Get all the videos that have been added to an embed preset
@@ -1505,10 +1492,10 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The videos were returned. 
     remote isolated function getEmbedPresetVideosAlt1(decimal presetId, decimal? page = (), decimal? perPage = ()) returns Video[]|error {
-        string  path = string `/me/presets/${presetId}/videos`;
+        string resourcePath = string `/me/presets/${presetId}/videos`;
         map<anydata> queryParam = {"page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the projects that belong to a user
@@ -1519,21 +1506,21 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The projects were returned. 
     remote isolated function getProjectsAlt1(string? direction = (), decimal? page = (), decimal? perPage = (), string? sort = ()) returns Project[]|error {
-        string  path = string `/me/projects`;
+        string resourcePath = string `/me/projects`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Project[] response = check self.clientEp-> get(path, targetType = ProjectArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Project[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Create a project
     #
     # + return - The project was created. 
-    remote isolated function createProjectAlt1(Body24 payload) returns Project|error {
-        string  path = string `/me/projects`;
+    remote isolated function createProjectAlt1(MeProjectsBody payload) returns Project|error {
+        string resourcePath = string `/me/projects`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Project response = check self.clientEp->post(path, request, targetType=Project);
+        request.setPayload(jsonBody, "application/json");
+        Project response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Get a specific project
@@ -1541,8 +1528,8 @@ public isolated client class Client {
     # + projectId - The ID of the project. 
     # + return - The project was returned. 
     remote isolated function getProjectAlt1(decimal projectId) returns Project|error {
-        string  path = string `/me/projects/${projectId}`;
-        Project response = check self.clientEp-> get(path, targetType = Project);
+        string resourcePath = string `/me/projects/${projectId}`;
+        Project response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Delete a project
@@ -1551,22 +1538,22 @@ public isolated client class Client {
     # + shouldDeleteClips - Whether to delete all the videos in the project along with the project itself. 
     # + return - The project was deleted. 
     remote isolated function deleteProjectAlt1(decimal projectId, boolean? shouldDeleteClips = ()) returns http:Response|error {
-        string  path = string `/me/projects/${projectId}`;
+        string resourcePath = string `/me/projects/${projectId}`;
         map<anydata> queryParam = {"should_delete_clips": shouldDeleteClips};
-        path = path + check getPathForQueryParam(queryParam);
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Edit a project
     #
     # + projectId - The ID of the project. 
     # + return - The project was edited. 
-    remote isolated function editProjectAlt1(decimal projectId, Body25 payload) returns Project|error {
-        string  path = string `/me/projects/${projectId}`;
+    remote isolated function editProjectAlt1(decimal projectId, ProjectsProjectIdBody payload) returns Project|error {
+        string resourcePath = string `/me/projects/${projectId}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Project response = check self.clientEp->patch(path, request, targetType=Project);
+        request.setPayload(jsonBody, "application/json");
+        Project response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Get all the videos in a project
@@ -1578,10 +1565,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The videos were returned. 
     remote isolated function getProjectVideosAlt1(decimal projectId, string? direction = (), decimal? page = (), decimal? perPage = (), string? sort = ()) returns Video[]|error {
-        string  path = string `/me/projects/${projectId}/videos`;
+        string resourcePath = string `/me/projects/${projectId}/videos`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a list of videos to a project
@@ -1590,25 +1577,25 @@ public isolated client class Client {
     # + uris - A comma-separated list of video URIs to add. 
     # + return - The videos were added. 
     remote isolated function addVideosToProjectAlt1(decimal projectId, string uris) returns http:Response|error {
-        string  path = string `/me/projects/${projectId}/videos`;
+        string resourcePath = string `/me/projects/${projectId}/videos`;
         map<anydata> queryParam = {"uris": uris};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Remove a list of videos from a project
     #
     # + projectId - The ID of the project. 
-    # + uris - A comma-separated list of the video URIs to remove. 
     # + shouldDeleteClips - Whether to delete the videos when removing them from the project. 
+    # + uris - A comma-separated list of the video URIs to remove. 
     # + return - The videos were removed. 
     remote isolated function removeVideosFromProjectAlt1(decimal projectId, string uris, boolean? shouldDeleteClips = ()) returns http:Response|error {
-        string  path = string `/me/projects/${projectId}/videos`;
+        string resourcePath = string `/me/projects/${projectId}/videos`;
         map<anydata> queryParam = {"should_delete_clips": shouldDeleteClips, "uris": uris};
-        path = path + check getPathForQueryParam(queryParam);
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Add a specific video to a project
@@ -1617,10 +1604,10 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was added. 
     remote isolated function addVideoToProjectAlt1(decimal projectId, decimal videoId) returns http:Response|error {
-        string  path = string `/me/projects/${projectId}/videos/${videoId}`;
+        string resourcePath = string `/me/projects/${projectId}/videos/${videoId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Remove a specific video from a project
@@ -1629,8 +1616,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was removed. 
     remote isolated function removeVideoFromProjectAlt1(decimal projectId, decimal videoId) returns http:Response|error {
-        string  path = string `/me/projects/${projectId}/videos/${videoId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/me/projects/${projectId}/videos/${videoId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the videos that a user has uploaded
@@ -1646,21 +1633,20 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The videos were returned. 
     remote isolated function getVideosAlt1(string? containingUri = (), string? direction = (), string? filter = (), boolean? filterEmbeddable = (), boolean? filterPlayable = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Video[]|error {
-        string  path = string `/me/videos`;
+        string resourcePath = string `/me/videos`;
         map<anydata> queryParam = {"containing_uri": containingUri, "direction": direction, "filter": filter, "filter_embeddable": filterEmbeddable, "filter_playable": filterPlayable, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Upload a video
     #
     # + return - The upload procedure has begun. 
-    remote isolated function uploadVideoAlt1(Body26 payload) returns Video|error {
-        string  path = string `/me/videos`;
+    remote isolated function uploadVideoAlt1(byte[] payload) returns Video|error {
+        string resourcePath = string `/me/videos`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Video response = check self.clientEp->post(path, request, targetType=Video);
+        request.setPayload(payload, "application/vnd.vimeo.video+json");
+        Video response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Check if a user owns a video
@@ -1668,8 +1654,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The user owns the video. 
     remote isolated function checkIfUserOwnsVideoAlt1(decimal videoId) returns Video|error {
-        string  path = string `/me/videos/${videoId}`;
-        Video response = check self.clientEp-> get(path, targetType = Video);
+        string resourcePath = string `/me/videos/${videoId}`;
+        Video response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the videos that a user has watched
@@ -1678,18 +1664,18 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The videos were returned. 
     remote isolated function getWatchHistory(decimal? page = (), decimal? perPage = ()) returns Video[]|error {
-        string  path = string `/me/watched/videos`;
+        string resourcePath = string `/me/watched/videos`;
         map<anydata> queryParam = {"page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Delete a user's watch history
     #
     # + return - The watch history was deleted. 
     remote isolated function deleteWatchHistory() returns http:Response|error {
-        string  path = string `/me/watched/videos`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/me/watched/videos`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Delete a specific video from a user's watch history
@@ -1697,8 +1683,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was deleted from your watch history. 
     remote isolated function deleteFromWatchHistory(decimal videoId) returns http:Response|error {
-        string  path = string `/me/watched/videos/${videoId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/me/watched/videos/${videoId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the videos in a user's Watch Later queue
@@ -1712,10 +1698,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The videos were returned. 
     remote isolated function getWatchLaterQueueAlt1(string? direction = (), string? filter = (), boolean? filterEmbeddable = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Video[]|error {
-        string  path = string `/me/watchlater`;
+        string resourcePath = string `/me/watchlater`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "filter_embeddable": filterEmbeddable, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Check if a user has added a specific video to their Watch Later queue
@@ -1723,8 +1709,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video appears in the user's Watch Later queue. 
     remote isolated function checkWatchLaterQueueAlt1(decimal videoId) returns Video|error {
-        string  path = string `/me/watchlater/${videoId}`;
-        Video response = check self.clientEp-> get(path, targetType = Video);
+        string resourcePath = string `/me/watchlater/${videoId}`;
+        Video response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a video to a user's Watch Later queue
@@ -1732,10 +1718,10 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was added. 
     remote isolated function addVideoToWatchLaterAlt1(decimal videoId) returns http:Response|error {
-        string  path = string `/me/watchlater/${videoId}`;
+        string resourcePath = string `/me/watchlater/${videoId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Remove a video from a user's Watch Later queue
@@ -1743,57 +1729,54 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was deleted. 
     remote isolated function deleteVideoFromWatchLaterAlt1(decimal videoId) returns http:Response|error {
-        string  path = string `/me/watchlater/${videoId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/me/watchlater/${videoId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Exchange an authorization code for an access token
     #
     # + return - The authorization code was exchanged. 
-    remote isolated function exchangeAuthCode(Body27 payload) returns Auth|error {
-        string  path = string `/oauth/access_token`;
+    remote isolated function exchangeAuthCode(byte[] payload) returns Auth|error {
+        string resourcePath = string `/oauth/access_token`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Auth response = check self.clientEp->post(path, request, targetType=Auth);
+        request.setPayload(payload, "application/vnd.vimeo.auth+json");
+        Auth response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Authorize a client with OAuth
     #
     # + return - The authorization was successful. 
-    remote isolated function clientAuth(Body28 payload) returns Auth|error {
-        string  path = string `/oauth/authorize/client`;
+    remote isolated function clientAuth(byte[] payload) returns Auth|error {
+        string resourcePath = string `/oauth/authorize/client`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Auth response = check self.clientEp->post(path, request, targetType=Auth);
+        request.setPayload(payload, "application/vnd.vimeo.auth+json");
+        Auth response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Convert OAuth 1 access tokens to OAuth 2 access tokens
     #
     # + return - The tokens were converted. 
-    remote isolated function convertAccessToken(Body29 payload) returns Auth|error {
-        string  path = string `/oauth/authorize/vimeo_oauth1`;
+    remote isolated function convertAccessToken(byte[] payload) returns Auth|error {
+        string resourcePath = string `/oauth/authorize/vimeo_oauth1`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Auth response = check self.clientEp->post(path, request, targetType=Auth);
+        request.setPayload(payload, "application/vnd.vimeo.auth+json");
+        Auth response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Verify an OAuth 2 token
     #
     # + return - The token was verified. 
     remote isolated function verifyToken() returns Auth|error {
-        string  path = string `/oauth/verify`;
-        Auth response = check self.clientEp-> get(path, targetType = Auth);
+        string resourcePath = string `/oauth/verify`;
+        Auth response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all On Demand genres
     #
     # + return - The On Demand genres were returned. 
     remote isolated function getVodGenres() returns OnDemandGenre[]|error {
-        string  path = string `/ondemand/genres`;
-        OnDemandGenre[] response = check self.clientEp-> get(path, targetType = OnDemandGenreArr);
+        string resourcePath = string `/ondemand/genres`;
+        OnDemandGenre[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get a specific On Demand genre
@@ -1801,8 +1784,8 @@ public isolated client class Client {
     # + genreId - The ID of the genre. 
     # + return - The On Demand genre was returned. 
     remote isolated function getVodGenre(string genreId) returns OnDemandGenre|error {
-        string  path = string `/ondemand/genres/${genreId}`;
-        OnDemandGenre response = check self.clientEp-> get(path, targetType = OnDemandGenre);
+        string resourcePath = string `/ondemand/genres/${genreId}`;
+        OnDemandGenre response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the On Demand pages in a genre
@@ -1816,10 +1799,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The On Demand pages were returned. 
     remote isolated function getGenreVods(string genreId, string? direction = (), string? filter = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns OnDemandPage[]|error {
-        string  path = string `/ondemand/genres/${genreId}/pages`;
+        string resourcePath = string `/ondemand/genres/${genreId}/pages`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        OnDemandPage[] response = check self.clientEp-> get(path, targetType = OnDemandPageArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        OnDemandPage[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get a specific On Demand page in a genre
@@ -1828,8 +1811,8 @@ public isolated client class Client {
     # + ondemandId - The ID of the On Demand. 
     # + return - The On Demand page belongs to the genre. 
     remote isolated function getGenreVod(string genreId, decimal ondemandId) returns OnDemandPage|error {
-        string  path = string `/ondemand/genres/${genreId}/pages/${ondemandId}`;
-        OnDemandPage response = check self.clientEp-> get(path, targetType = OnDemandPage);
+        string resourcePath = string `/ondemand/genres/${genreId}/pages/${ondemandId}`;
+        OnDemandPage response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get a specific On Demand page
@@ -1837,8 +1820,8 @@ public isolated client class Client {
     # + ondemandId - The ID of the On Demand. 
     # + return - The On Demand page was returned. 
     remote isolated function getVod(decimal ondemandId) returns OnDemandPage|error {
-        string  path = string `/ondemand/pages/${ondemandId}`;
-        OnDemandPage response = check self.clientEp-> get(path, targetType = OnDemandPage);
+        string resourcePath = string `/ondemand/pages/${ondemandId}`;
+        OnDemandPage response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Delete a draft of an On Demand page
@@ -1846,20 +1829,19 @@ public isolated client class Client {
     # + ondemandId - The ID of the On Demand. 
     # + return - The page draft was deleted. 
     remote isolated function deleteVodDraft(decimal ondemandId) returns http:Response|error {
-        string  path = string `/ondemand/pages/${ondemandId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/ondemand/pages/${ondemandId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Edit an On Demand page
     #
     # + ondemandId - The ID of the On Demand. 
     # + return - The On Demand page was edited. 
-    remote isolated function editVod(decimal ondemandId, Body30 payload) returns OnDemandPage|error {
-        string  path = string `/ondemand/pages/${ondemandId}`;
+    remote isolated function editVod(decimal ondemandId, byte[] payload) returns OnDemandPage|error {
+        string resourcePath = string `/ondemand/pages/${ondemandId}`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        OnDemandPage response = check self.clientEp->patch(path, request, targetType=OnDemandPage);
+        request.setPayload(payload, "application/vnd.vimeo.ondemand.page+json");
+        OnDemandPage response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Get all the backgrounds of an On Demand page
@@ -1869,10 +1851,10 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The background images were returned. 
     remote isolated function getVodBackgrounds(decimal ondemandId, decimal? page = (), decimal? perPage = ()) returns Picture[]|error {
-        string  path = string `/ondemand/pages/${ondemandId}/backgrounds`;
+        string resourcePath = string `/ondemand/pages/${ondemandId}/backgrounds`;
         map<anydata> queryParam = {"page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        Picture[] response = check self.clientEp-> get(path, targetType = PictureArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Picture[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a background to an On Demand page
@@ -1880,10 +1862,10 @@ public isolated client class Client {
     # + ondemandId - The ID of the On Demand. 
     # + return - The background was created. 
     remote isolated function createVodBackground(decimal ondemandId) returns Picture|error {
-        string  path = string `/ondemand/pages/${ondemandId}/backgrounds`;
+        string resourcePath = string `/ondemand/pages/${ondemandId}/backgrounds`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        Picture response = check self.clientEp-> post(path, request, targetType = Picture);
+        Picture response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     # Get a specific background of an On Demand page
@@ -1892,8 +1874,8 @@ public isolated client class Client {
     # + ondemandId - The ID of the On Demand. 
     # + return - The background image was returned. 
     remote isolated function getVodBackground(decimal backgroundId, decimal ondemandId) returns Picture|error {
-        string  path = string `/ondemand/pages/${ondemandId}/backgrounds/${backgroundId}`;
-        Picture response = check self.clientEp-> get(path, targetType = Picture);
+        string resourcePath = string `/ondemand/pages/${ondemandId}/backgrounds/${backgroundId}`;
+        Picture response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Remove a background from an On Demand page
@@ -1902,8 +1884,8 @@ public isolated client class Client {
     # + ondemandId - The ID of the On Demand. 
     # + return - The background image was deleted. 
     remote isolated function deleteVodBackground(decimal backgroundId, decimal ondemandId) returns Picture|error {
-        string  path = string `/ondemand/pages/${ondemandId}/backgrounds/${backgroundId}`;
-        Picture response = check self.clientEp-> delete(path, targetType = Picture);
+        string resourcePath = string `/ondemand/pages/${ondemandId}/backgrounds/${backgroundId}`;
+        Picture response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Edit a background of an On Demand page
@@ -1911,12 +1893,11 @@ public isolated client class Client {
     # + backgroundId - The ID of the background. 
     # + ondemandId - The ID of the On Demand. 
     # + return - The background was edited. 
-    remote isolated function editVodBackground(decimal backgroundId, decimal ondemandId, Body31 payload) returns Picture|error {
-        string  path = string `/ondemand/pages/${ondemandId}/backgrounds/${backgroundId}`;
+    remote isolated function editVodBackground(decimal backgroundId, decimal ondemandId, byte[] payload) returns Picture|error {
+        string resourcePath = string `/ondemand/pages/${ondemandId}/backgrounds/${backgroundId}`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Picture response = check self.clientEp->patch(path, request, targetType=Picture);
+        request.setPayload(payload, "application/vnd.vimeo.picture+json");
+        Picture response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Get all the genres of an On Demand page
@@ -1924,8 +1905,8 @@ public isolated client class Client {
     # + ondemandId - The ID of the On Demand. 
     # + return - The genres were returned. 
     remote isolated function getVodGenresByOndemandId(decimal ondemandId) returns OnDemandGenre[]|error {
-        string  path = string `/ondemand/pages/${ondemandId}/genres`;
-        OnDemandGenre[] response = check self.clientEp-> get(path, targetType = OnDemandGenreArr);
+        string resourcePath = string `/ondemand/pages/${ondemandId}/genres`;
+        OnDemandGenre[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Check whether an On Demand page belongs to a genre
@@ -1934,8 +1915,8 @@ public isolated client class Client {
     # + ondemandId - The ID of the On Demand. 
     # + return - The On Demand page's genre was returned. 
     remote isolated function getVodGenreByOndemandId(string genreId, decimal ondemandId) returns OnDemandGenre|error {
-        string  path = string `/ondemand/pages/${ondemandId}/genres/${genreId}`;
-        OnDemandGenre response = check self.clientEp-> get(path, targetType = OnDemandGenre);
+        string resourcePath = string `/ondemand/pages/${ondemandId}/genres/${genreId}`;
+        OnDemandGenre response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a genre to an On Demand page
@@ -1944,10 +1925,10 @@ public isolated client class Client {
     # + ondemandId - The ID of the On Demand. 
     # + return - The genre was added. 
     remote isolated function addVodGenre(string genreId, decimal ondemandId) returns OnDemandGenre|error {
-        string  path = string `/ondemand/pages/${ondemandId}/genres/${genreId}`;
+        string resourcePath = string `/ondemand/pages/${ondemandId}/genres/${genreId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        OnDemandGenre response = check self.clientEp-> put(path, request, targetType = OnDemandGenre);
+        OnDemandGenre response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Remove a genre from an On Demand page
@@ -1956,8 +1937,8 @@ public isolated client class Client {
     # + ondemandId - The ID of the On Demand. 
     # + return - The On Demand genre was deleted. 
     remote isolated function deleteVodGenre(string genreId, decimal ondemandId) returns http:Response|error {
-        string  path = string `/ondemand/pages/${ondemandId}/genres/${genreId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/ondemand/pages/${ondemandId}/genres/${genreId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the users who have liked a video on an On Demand page
@@ -1970,10 +1951,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The users were returned. 
     remote isolated function getVodLikes(decimal ondemandId, string? direction = (), string? filter = (), decimal? page = (), decimal? perPage = (), string? sort = ()) returns User[]|error {
-        string  path = string `/ondemand/pages/${ondemandId}/likes`;
+        string resourcePath = string `/ondemand/pages/${ondemandId}/likes`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "page": page, "per_page": perPage, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        User[] response = check self.clientEp-> get(path, targetType = UserArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        User[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the posters of an On Demand page
@@ -1983,10 +1964,10 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The posters were returned. 
     remote isolated function getVodPosters(decimal ondemandId, decimal? page = (), decimal? perPage = ()) returns Picture[]|error {
-        string  path = string `/ondemand/pages/${ondemandId}/pictures`;
+        string resourcePath = string `/ondemand/pages/${ondemandId}/pictures`;
         map<anydata> queryParam = {"page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        Picture[] response = check self.clientEp-> get(path, targetType = PictureArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Picture[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a poster to an On Demand page
@@ -1994,10 +1975,10 @@ public isolated client class Client {
     # + ondemandId - The ID of the On Demand. 
     # + return - The poster was added. 
     remote isolated function addVodPoster(decimal ondemandId) returns Picture|error {
-        string  path = string `/ondemand/pages/${ondemandId}/pictures`;
+        string resourcePath = string `/ondemand/pages/${ondemandId}/pictures`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        Picture response = check self.clientEp-> post(path, request, targetType = Picture);
+        Picture response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     # Get a specific poster of an On Demand page
@@ -2006,8 +1987,8 @@ public isolated client class Client {
     # + posterId - The ID of the picture. 
     # + return - The poster was returned. 
     remote isolated function getVodPoster(decimal ondemandId, decimal posterId) returns Picture|error {
-        string  path = string `/ondemand/pages/${ondemandId}/pictures/${posterId}`;
-        Picture response = check self.clientEp-> get(path, targetType = Picture);
+        string resourcePath = string `/ondemand/pages/${ondemandId}/pictures/${posterId}`;
+        Picture response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Edit a poster of an On Demand page
@@ -2015,12 +1996,11 @@ public isolated client class Client {
     # + ondemandId - The ID of the On Demand. 
     # + posterId - The ID of the picture. 
     # + return - The poster was edited. 
-    remote isolated function editVodPoster(decimal ondemandId, decimal posterId, Body32 payload) returns Picture|error {
-        string  path = string `/ondemand/pages/${ondemandId}/pictures/${posterId}`;
+    remote isolated function editVodPoster(decimal ondemandId, decimal posterId, byte[] payload) returns Picture|error {
+        string resourcePath = string `/ondemand/pages/${ondemandId}/pictures/${posterId}`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Picture response = check self.clientEp->patch(path, request, targetType=Picture);
+        request.setPayload(payload, "application/vnd.vimeo.picture+json");
+        Picture response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Get all the promotions on an On Demand page
@@ -2031,22 +2011,21 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The promotions were returned. 
     remote isolated function getVodPromotions(decimal ondemandId, string filter, decimal? page = (), decimal? perPage = ()) returns OnDemandPromotion|error {
-        string  path = string `/ondemand/pages/${ondemandId}/promotions`;
+        string resourcePath = string `/ondemand/pages/${ondemandId}/promotions`;
         map<anydata> queryParam = {"filter": filter, "page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        OnDemandPromotion response = check self.clientEp-> get(path, targetType = OnDemandPromotion);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        OnDemandPromotion response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a promotion to an On Demand page
     #
     # + ondemandId - The ID of the On Demand. 
     # + return - The promotion was added. 
-    remote isolated function createVodPromotion(decimal ondemandId, Body33 payload) returns OnDemandPromotion|error {
-        string  path = string `/ondemand/pages/${ondemandId}/promotions`;
+    remote isolated function createVodPromotion(decimal ondemandId, byte[] payload) returns OnDemandPromotion|error {
+        string resourcePath = string `/ondemand/pages/${ondemandId}/promotions`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        OnDemandPromotion response = check self.clientEp->post(path, request, targetType=OnDemandPromotion);
+        request.setPayload(payload, "application/vnd.vimeo.ondemand.promotion+json");
+        OnDemandPromotion response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Get a specific promotion on an On Demand page
@@ -2055,8 +2034,8 @@ public isolated client class Client {
     # + promotionId - The ID of the promotion. 
     # + return - The promotion was returned. 
     remote isolated function getVodPromotion(decimal ondemandId, decimal promotionId) returns OnDemandPromotion|error {
-        string  path = string `/ondemand/pages/${ondemandId}/promotions/${promotionId}`;
-        OnDemandPromotion response = check self.clientEp-> get(path, targetType = OnDemandPromotion);
+        string resourcePath = string `/ondemand/pages/${ondemandId}/promotions/${promotionId}`;
+        OnDemandPromotion response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Remove a promotion from an On Demand page
@@ -2065,8 +2044,8 @@ public isolated client class Client {
     # + promotionId - The ID of the promotion. 
     # + return - The promotion was deleted. 
     remote isolated function deleteVodPromotion(decimal ondemandId, decimal promotionId) returns http:Response|error {
-        string  path = string `/ondemand/pages/${ondemandId}/promotions/${promotionId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/ondemand/pages/${ondemandId}/promotions/${promotionId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the codes of a promotion on an On Demand page
@@ -2077,10 +2056,10 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The codes were returned. 
     remote isolated function getVodPromotionCodes(decimal ondemandId, decimal promotionId, decimal? page = (), decimal? perPage = ()) returns OnDemandPromotionCode|error {
-        string  path = string `/ondemand/pages/${ondemandId}/promotions/${promotionId}/codes`;
+        string resourcePath = string `/ondemand/pages/${ondemandId}/promotions/${promotionId}/codes`;
         map<anydata> queryParam = {"page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        OnDemandPromotionCode response = check self.clientEp-> get(path, targetType = OnDemandPromotionCode);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        OnDemandPromotionCode response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the regions of an On Demand page
@@ -2088,32 +2067,28 @@ public isolated client class Client {
     # + ondemandId - The ID of the On Demand. 
     # + return - The regions were returned. 
     remote isolated function getVodRegions(decimal ondemandId) returns OnDemandRegion[]|error {
-        string  path = string `/ondemand/pages/${ondemandId}/regions`;
-        OnDemandRegion[] response = check self.clientEp-> get(path, targetType = OnDemandRegionArr);
+        string resourcePath = string `/ondemand/pages/${ondemandId}/regions`;
+        OnDemandRegion[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a list of regions to an On Demand page
     #
     # + ondemandId - The ID of the On Demand. 
     # + return - The list of regions was set. 
-    remote isolated function setVodRegions(decimal ondemandId, Body34 payload) returns OnDemandRegion|error {
-        string  path = string `/ondemand/pages/${ondemandId}/regions`;
+    remote isolated function setVodRegions(decimal ondemandId, byte[] payload) returns OnDemandRegion|error {
+        string resourcePath = string `/ondemand/pages/${ondemandId}/regions`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        OnDemandRegion response = check self.clientEp->put(path, request, targetType=OnDemandRegion);
+        request.setPayload(payload, "application/vnd.vimeo.ondemand.region+json");
+        OnDemandRegion response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     # Remove a list of regions from an On Demand page
     #
     # + ondemandId - The ID of the On Demand. 
     # + return - The On Demand regions were deleted. 
-    remote isolated function deleteVodRegions(decimal ondemandId, Body35 payload) returns OnDemandRegion[]|error {
-        string  path = string `/ondemand/pages/${ondemandId}/regions`;
-        http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        OnDemandRegion[] response = check self.clientEp->delete(path, request, targetType=OnDemandRegionArr);
+    remote isolated function deleteVodRegions(decimal ondemandId) returns OnDemandRegion[]|error {
+        string resourcePath = string `/ondemand/pages/${ondemandId}/regions`;
+        OnDemandRegion[] response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get a specific region of an On Demand page
@@ -2122,8 +2097,8 @@ public isolated client class Client {
     # + ondemandId - The ID of the On Demand. 
     # + return - The On Demand page's region was returned. 
     remote isolated function getVodRegion(string country, decimal ondemandId) returns OnDemandRegion|error {
-        string  path = string `/ondemand/pages/${ondemandId}/regions/${country}`;
-        OnDemandRegion response = check self.clientEp-> get(path, targetType = OnDemandRegion);
+        string resourcePath = string `/ondemand/pages/${ondemandId}/regions/${country}`;
+        OnDemandRegion response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a specific region to an On Demand page
@@ -2132,10 +2107,10 @@ public isolated client class Client {
     # + ondemandId - The ID of the On Demand. 
     # + return - The region was added. 
     remote isolated function addVodRegion(string country, decimal ondemandId) returns OnDemandRegion|error {
-        string  path = string `/ondemand/pages/${ondemandId}/regions/${country}`;
+        string resourcePath = string `/ondemand/pages/${ondemandId}/regions/${country}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        OnDemandRegion response = check self.clientEp-> put(path, request, targetType = OnDemandRegion);
+        OnDemandRegion response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Remove a specific region from an On Demand page
@@ -2144,8 +2119,8 @@ public isolated client class Client {
     # + ondemandId - The ID of the On Demand. 
     # + return - The On Demand region was deleted. 
     remote isolated function deleteVodRegion(string country, decimal ondemandId) returns http:Response|error {
-        string  path = string `/ondemand/pages/${ondemandId}/regions/${country}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/ondemand/pages/${ondemandId}/regions/${country}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the seasons on an On Demand page
@@ -2158,10 +2133,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The seasons were returned. 
     remote isolated function getVodSeasons(decimal ondemandId, string? direction = (), string? filter = (), decimal? page = (), decimal? perPage = (), string? sort = ()) returns OnDemandSeason[]|error {
-        string  path = string `/ondemand/pages/${ondemandId}/seasons`;
+        string resourcePath = string `/ondemand/pages/${ondemandId}/seasons`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "page": page, "per_page": perPage, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        OnDemandSeason[] response = check self.clientEp-> get(path, targetType = OnDemandSeasonArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        OnDemandSeason[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get a specific season on an On Demand page
@@ -2170,8 +2145,8 @@ public isolated client class Client {
     # + seasonId - The ID of the season. 
     # + return - The season was returned. 
     remote isolated function getVodSeason(decimal ondemandId, decimal seasonId) returns OnDemandSeason|error {
-        string  path = string `/ondemand/pages/${ondemandId}/seasons/${seasonId}`;
-        OnDemandSeason response = check self.clientEp-> get(path, targetType = OnDemandSeason);
+        string resourcePath = string `/ondemand/pages/${ondemandId}/seasons/${seasonId}`;
+        OnDemandSeason response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the videos in a season on an On Demand page
@@ -2184,10 +2159,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The videos were returned. 
     remote isolated function getVodSeasonVideos(decimal ondemandId, decimal seasonId, string? filter = (), decimal? page = (), decimal? perPage = (), string? sort = ()) returns Video[]|error {
-        string  path = string `/ondemand/pages/${ondemandId}/seasons/${seasonId}/videos`;
+        string resourcePath = string `/ondemand/pages/${ondemandId}/seasons/${seasonId}/videos`;
         map<anydata> queryParam = {"filter": filter, "page": page, "per_page": perPage, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the videos on an On Demand page
@@ -2200,10 +2175,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - * The videos were returned. * The videos were returned. 
     remote isolated function getVodVideos(decimal ondemandId, string? direction = (), string? filter = (), decimal? page = (), decimal? perPage = (), string? sort = ()) returns Video[]|error {
-        string  path = string `/ondemand/pages/${ondemandId}/videos`;
+        string resourcePath = string `/ondemand/pages/${ondemandId}/videos`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "page": page, "per_page": perPage, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get a specific video on an On Demand page
@@ -2212,8 +2187,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video is on the On Demand page. 
     remote isolated function getVodVideo(decimal ondemandId, decimal videoId) returns Video|error {
-        string  path = string `/ondemand/pages/${ondemandId}/videos/${videoId}`;
-        Video response = check self.clientEp-> get(path, targetType = Video);
+        string resourcePath = string `/ondemand/pages/${ondemandId}/videos/${videoId}`;
+        Video response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a video to an On Demand page
@@ -2221,12 +2196,11 @@ public isolated client class Client {
     # + ondemandId - The ID of the On Demand. 
     # + videoId - The ID of the video. 
     # + return - The video was added. 
-    remote isolated function addVideoToVod(decimal ondemandId, decimal videoId, Body36 payload) returns OnDemandVideo|error {
-        string  path = string `/ondemand/pages/${ondemandId}/videos/${videoId}`;
+    remote isolated function addVideoToVod(decimal ondemandId, decimal videoId, byte[] payload) returns OnDemandVideo|error {
+        string resourcePath = string `/ondemand/pages/${ondemandId}/videos/${videoId}`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        OnDemandVideo response = check self.clientEp->put(path, request, targetType=OnDemandVideo);
+        request.setPayload(payload, "application/vnd.vimeo.ondemand.video+json");
+        OnDemandVideo response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     # Remove a video from an On Demand page
@@ -2235,16 +2209,16 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was deleted. 
     remote isolated function deleteVideoFromVod(decimal ondemandId, decimal videoId) returns http:Response|error {
-        string  path = string `/ondemand/pages/${ondemandId}/videos/${videoId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/ondemand/pages/${ondemandId}/videos/${videoId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the On Demand regions
     #
     # + return - The On Demand regions were returned. 
     remote isolated function getRegions() returns OnDemandRegion[]|error {
-        string  path = string `/ondemand/regions`;
-        OnDemandRegion[] response = check self.clientEp-> get(path, targetType = OnDemandRegionArr);
+        string resourcePath = string `/ondemand/regions`;
+        OnDemandRegion[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get a specific On Demand region
@@ -2252,8 +2226,8 @@ public isolated client class Client {
     # + country - The country code. 
     # + return - The On Demand region was returned. 
     remote isolated function getRegion(string country) returns OnDemandRegion|error {
-        string  path = string `/ondemand/regions/${country}`;
-        OnDemandRegion response = check self.clientEp-> get(path, targetType = OnDemandRegion);
+        string resourcePath = string `/ondemand/regions/${country}`;
+        OnDemandRegion response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get a specific tag
@@ -2261,8 +2235,8 @@ public isolated client class Client {
     # + word - The tag to return. 
     # + return - The tag was returned. 
     remote isolated function getTag(string word) returns Tag|error {
-        string  path = string `/tags/${word}`;
-        Tag response = check self.clientEp-> get(path, targetType = Tag);
+        string resourcePath = string `/tags/${word}`;
+        Tag response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the videos with a specific tag
@@ -2274,18 +2248,18 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The videos were returned. 
     remote isolated function getVideosWithTag(string word, string? direction = (), decimal? page = (), decimal? perPage = (), string? sort = ()) returns Video[]|error {
-        string  path = string `/tags/${word}/videos`;
+        string resourcePath = string `/tags/${word}/videos`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Revoke the current access token
     #
     # + return - The token was revoked. 
     remote isolated function deleteToken() returns Auth|error {
-        string  path = string `/tokens`;
-        Auth response = check self.clientEp-> delete(path, targetType = Auth);
+        string resourcePath = string `/tokens`;
+        Auth response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Search for users
@@ -2297,10 +2271,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The search results were returned. 
     remote isolated function searchUsers(string? direction = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns User[]|error {
-        string  path = string `/users`;
+        string resourcePath = string `/users`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        User[] response = check self.clientEp-> get(path, targetType = UserArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        User[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get a user
@@ -2308,20 +2282,19 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The user was returned. 
     remote isolated function getUser(decimal userId) returns User|error {
-        string  path = string `/users/${userId}`;
-        User response = check self.clientEp-> get(path, targetType = User);
+        string resourcePath = string `/users/${userId}`;
+        User response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Edit a user
     #
     # + userId - The ID of the user. 
     # + return - The user was edited. 
-    remote isolated function editUser(decimal userId, Body37 payload) returns User|error {
-        string  path = string `/users/${userId}`;
+    remote isolated function editUser(decimal userId, byte[] payload) returns User|error {
+        string resourcePath = string `/users/${userId}`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        User response = check self.clientEp->patch(path, request, targetType=User);
+        request.setPayload(payload, "application/vnd.vimeo.user+json");
+        User response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Get all the albums that belong to a user
@@ -2334,22 +2307,21 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The albums were returned. 
     remote isolated function getAlbums(decimal userId, string? direction = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Album[]|error {
-        string  path = string `/users/${userId}/albums`;
+        string resourcePath = string `/users/${userId}/albums`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Album[] response = check self.clientEp-> get(path, targetType = AlbumArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Album[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Create an album
     #
     # + userId - The ID of the user. 
     # + return - The album was created. 
-    remote isolated function createAlbum(decimal userId, Body38 payload) returns Album|error {
-        string  path = string `/users/${userId}/albums`;
+    remote isolated function createAlbum(decimal userId, byte[] payload) returns Album|error {
+        string resourcePath = string `/users/${userId}/albums`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Album response = check self.clientEp->post(path, request, targetType=Album);
+        request.setPayload(payload, "application/vnd.vimeo.album+json");
+        Album response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Get a specific album
@@ -2358,8 +2330,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The album was returned. 
     remote isolated function getAlbum(decimal albumId, decimal userId) returns Album|error {
-        string  path = string `/users/${userId}/albums/${albumId}`;
-        Album response = check self.clientEp-> get(path, targetType = Album);
+        string resourcePath = string `/users/${userId}/albums/${albumId}`;
+        Album response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Delete an album
@@ -2368,8 +2340,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The album was deleted. 
     remote isolated function deleteAlbum(decimal albumId, decimal userId) returns http:Response|error {
-        string  path = string `/users/${userId}/albums/${albumId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/users/${userId}/albums/${albumId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Edit an album
@@ -2377,12 +2349,11 @@ public isolated client class Client {
     # + albumId - The ID of the album. 
     # + userId - The ID of the user. 
     # + return - The album was edited. 
-    remote isolated function editAlbum(decimal albumId, decimal userId, Body39 payload) returns Album|error {
-        string  path = string `/users/${userId}/albums/${albumId}`;
+    remote isolated function editAlbum(decimal albumId, decimal userId, byte[] payload) returns Album|error {
+        string resourcePath = string `/users/${userId}/albums/${albumId}`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Album response = check self.clientEp->patch(path, request, targetType=Album);
+        request.setPayload(payload, "application/vnd.vimeo.album+json");
+        Album response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Get all the custom upload thumbnails of an album
@@ -2393,10 +2364,10 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The custom uploaded thumbnails were returned. 
     remote isolated function getAlbumCustomThumbs(decimal albumId, decimal userId, decimal? page = (), decimal? perPage = ()) returns Picture[]|error {
-        string  path = string `/users/${userId}/albums/${albumId}/custom_thumbnails`;
+        string resourcePath = string `/users/${userId}/albums/${albumId}/custom_thumbnails`;
         map<anydata> queryParam = {"page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        Picture[] response = check self.clientEp-> get(path, targetType = PictureArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Picture[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a custom uploaded thumbnail
@@ -2405,10 +2376,10 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The custom thumbnail was added to the album. 
     remote isolated function createAlbumCustomThumb(decimal albumId, decimal userId) returns Picture|error {
-        string  path = string `/users/${userId}/albums/${albumId}/custom_thumbnails`;
+        string resourcePath = string `/users/${userId}/albums/${albumId}/custom_thumbnails`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        Picture response = check self.clientEp-> post(path, request, targetType = Picture);
+        Picture response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     # Get a specific custom uploaded album thumbnail
@@ -2418,8 +2389,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The custom thumbnail was returned. 
     remote isolated function getAlbumCustomThumbnail(decimal albumId, decimal thumbnailId, decimal userId) returns Picture|error {
-        string  path = string `/users/${userId}/albums/${albumId}/custom_thumbnails/${thumbnailId}`;
-        Picture response = check self.clientEp-> get(path, targetType = Picture);
+        string resourcePath = string `/users/${userId}/albums/${albumId}/custom_thumbnails/${thumbnailId}`;
+        Picture response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Remove a custom uploaded album thumbnail
@@ -2429,8 +2400,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The custom thumbnail was removed. 
     remote isolated function deleteAlbumCustomThumbnail(decimal albumId, decimal thumbnailId, decimal userId) returns http:Response|error {
-        string  path = string `/users/${userId}/albums/${albumId}/custom_thumbnails/${thumbnailId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/users/${userId}/albums/${albumId}/custom_thumbnails/${thumbnailId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Replace a custom uploaded album thumbnail
@@ -2439,12 +2410,11 @@ public isolated client class Client {
     # + thumbnailId - The ID of the custom thumbnail. 
     # + userId - The ID of the user. 
     # + return - The custom thumbnail was replaced. 
-    remote isolated function replaceAlbumCustomThumb(decimal albumId, decimal thumbnailId, decimal userId, Body40 payload) returns Picture|error {
-        string  path = string `/users/${userId}/albums/${albumId}/custom_thumbnails/${thumbnailId}`;
+    remote isolated function replaceAlbumCustomThumb(decimal albumId, decimal thumbnailId, decimal userId, byte[] payload) returns Picture|error {
+        string resourcePath = string `/users/${userId}/albums/${albumId}/custom_thumbnails/${thumbnailId}`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Picture response = check self.clientEp->patch(path, request, targetType=Picture);
+        request.setPayload(payload, "application/vnd.vimeo.picture+json");
+        Picture response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Get all the custom logos of an album
@@ -2455,10 +2425,10 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The custom logos were returned. 
     remote isolated function getAlbumLogos(decimal albumId, decimal userId, decimal? page = (), decimal? perPage = ()) returns Picture[]|error {
-        string  path = string `/users/${userId}/albums/${albumId}/logos`;
+        string resourcePath = string `/users/${userId}/albums/${albumId}/logos`;
         map<anydata> queryParam = {"page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        Picture[] response = check self.clientEp-> get(path, targetType = PictureArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Picture[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a custom album logo
@@ -2467,10 +2437,10 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The logo was added to the album. 
     remote isolated function createAlbumLogo(decimal albumId, decimal userId) returns Picture|error {
-        string  path = string `/users/${userId}/albums/${albumId}/logos`;
+        string resourcePath = string `/users/${userId}/albums/${albumId}/logos`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        Picture response = check self.clientEp-> post(path, request, targetType = Picture);
+        Picture response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     # Get a specific custom album logo
@@ -2480,8 +2450,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The custom logo was returned. 
     remote isolated function getAlbumLogo(decimal albumId, decimal logoId, decimal userId) returns Picture|error {
-        string  path = string `/users/${userId}/albums/${albumId}/logos/${logoId}`;
-        Picture response = check self.clientEp-> get(path, targetType = Picture);
+        string resourcePath = string `/users/${userId}/albums/${albumId}/logos/${logoId}`;
+        Picture response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Remove a custom album logo
@@ -2491,8 +2461,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The custom logo was removed. 
     remote isolated function deleteAlbumLogo(decimal albumId, decimal logoId, decimal userId) returns http:Response|error {
-        string  path = string `/users/${userId}/albums/${albumId}/logos/${logoId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/users/${userId}/albums/${albumId}/logos/${logoId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Replace a custom album logo
@@ -2501,12 +2471,11 @@ public isolated client class Client {
     # + logoId - The ID of the custom logo. 
     # + userId - The ID of the user. 
     # + return - The custom logo was replaced. 
-    remote isolated function replaceAlbumLogo(decimal albumId, decimal logoId, decimal userId, Body41 payload) returns Picture|error {
-        string  path = string `/users/${userId}/albums/${albumId}/logos/${logoId}`;
+    remote isolated function replaceAlbumLogo(decimal albumId, decimal logoId, decimal userId, byte[] payload) returns Picture|error {
+        string resourcePath = string `/users/${userId}/albums/${albumId}/logos/${logoId}`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Picture response = check self.clientEp->patch(path, request, targetType=Picture);
+        request.setPayload(payload, "application/vnd.vimeo.picture+json");
+        Picture response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Get all the videos in an album
@@ -2525,10 +2494,10 @@ public isolated client class Client {
     # + weakSearch - Whether to include private videos in the search. Please note that a separate search service provides this functionality. The service performs a partial text search on the video's name. 
     # + return - The videos were returned. 
     remote isolated function getAlbumVideos(decimal albumId, decimal userId, string? containingUri = (), string? direction = (), string? filter = (), boolean? filterEmbeddable = (), decimal? page = (), string? password = (), decimal? perPage = (), string? query = (), string? sort = (), boolean? weakSearch = ()) returns Video[]|error {
-        string  path = string `/users/${userId}/albums/${albumId}/videos`;
+        string resourcePath = string `/users/${userId}/albums/${albumId}/videos`;
         map<anydata> queryParam = {"containing_uri": containingUri, "direction": direction, "filter": filter, "filter_embeddable": filterEmbeddable, "page": page, "password": password, "per_page": perPage, "query": query, "sort": sort, "weak_search": weakSearch};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Replace all the videos in an album
@@ -2536,12 +2505,12 @@ public isolated client class Client {
     # + albumId - The ID of the album. 
     # + userId - The ID of the user. 
     # + return - The videos were added. 
-    remote isolated function replaceVideosInAlbum(decimal albumId, decimal userId, Body42 payload) returns http:Response|error {
-        string  path = string `/users/${userId}/albums/${albumId}/videos`;
+    remote isolated function replaceVideosInAlbum(decimal albumId, decimal userId, AlbumIdVideosBody1 payload) returns http:Response|error {
+        string resourcePath = string `/users/${userId}/albums/${albumId}/videos`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        http:Response response = check self.clientEp->put(path, request, targetType=http:Response);
+        request.setPayload(jsonBody, "application/json");
+        http:Response response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     # Get a specific video in an album
@@ -2552,10 +2521,10 @@ public isolated client class Client {
     # + password - The password of the album. 
     # + return - The video was returned. 
     remote isolated function getAlbumVideo(decimal albumId, decimal userId, decimal videoId, string? password = ()) returns Video|error {
-        string  path = string `/users/${userId}/albums/${albumId}/videos/${videoId}`;
+        string resourcePath = string `/users/${userId}/albums/${albumId}/videos/${videoId}`;
         map<anydata> queryParam = {"password": password};
-        path = path + check getPathForQueryParam(queryParam);
-        Video response = check self.clientEp-> get(path, targetType = Video);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a specific video to an album
@@ -2565,10 +2534,10 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was added. 
     remote isolated function addVideoToAlbum(decimal albumId, decimal userId, decimal videoId) returns http:Response|error {
-        string  path = string `/users/${userId}/albums/${albumId}/videos/${videoId}`;
+        string resourcePath = string `/users/${userId}/albums/${albumId}/videos/${videoId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Remove a video from an album
@@ -2578,8 +2547,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was removed. 
     remote isolated function removeVideoFromAlbum(decimal albumId, decimal userId, decimal videoId) returns http:Response|error {
-        string  path = string `/users/${userId}/albums/${albumId}/videos/${videoId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/users/${userId}/albums/${albumId}/videos/${videoId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Set a video as the album thumbnail
@@ -2588,12 +2557,12 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + videoId - The ID of the video. 
     # + return - The album was updated with a new thumbnail. 
-    remote isolated function setVideoAsAlbumThumbnail(decimal albumId, decimal userId, decimal videoId, Body43 payload) returns Album|error {
-        string  path = string `/users/${userId}/albums/${albumId}/videos/${videoId}/set_album_thumbnail`;
+    remote isolated function setVideoAsAlbumThumbnail(decimal albumId, decimal userId, decimal videoId, VideoIdSetAlbumThumbnailBody1 payload) returns Album|error {
+        string resourcePath = string `/users/${userId}/albums/${albumId}/videos/${videoId}/set_album_thumbnail`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Album response = check self.clientEp->post(path, request, targetType=Album);
+        request.setPayload(jsonBody, "application/json");
+        Album response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Get all the videos in which a user appears
@@ -2608,10 +2577,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The videos were returned. 
     remote isolated function getAppearances(decimal userId, string? direction = (), string? filter = (), boolean? filterEmbeddable = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Video[]|error {
-        string  path = string `/users/${userId}/appearances`;
+        string resourcePath = string `/users/${userId}/appearances`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "filter_embeddable": filterEmbeddable, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the categories that a user follows
@@ -2623,10 +2592,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The categories were returned. 
     remote isolated function getCategorySubscriptions(decimal userId, string? direction = (), decimal? page = (), decimal? perPage = (), string? sort = ()) returns Category[]|error {
-        string  path = string `/users/${userId}/categories`;
+        string resourcePath = string `/users/${userId}/categories`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Category[] response = check self.clientEp-> get(path, targetType = CategoryArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Category[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Check if a user follows a category
@@ -2635,8 +2604,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The user is following the category. 
     remote isolated function checkIfUserSubscribedToCategory(string category, decimal userId) returns http:Response|error {
-        string  path = string `/users/${userId}/categories/${category}`;
-        http:Response response = check self.clientEp-> get(path, targetType = http:Response);
+        string resourcePath = string `/users/${userId}/categories/${category}`;
+        http:Response response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Subscribe a user to a single category
@@ -2645,10 +2614,10 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The user was subscribed. 
     remote isolated function subscribeToCategory(decimal category, decimal userId) returns http:Response|error {
-        string  path = string `/users/${userId}/categories/${category}`;
+        string resourcePath = string `/users/${userId}/categories/${category}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Unsubscribe a user from a category
@@ -2657,8 +2626,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The user was unsubscribed. 
     remote isolated function unsubscribeFromCategory(string category, decimal userId) returns http:Response|error {
-        string  path = string `/users/${userId}/categories/${category}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/users/${userId}/categories/${category}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the channels to which a user subscribes
@@ -2672,10 +2641,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The channels were returned. 
     remote isolated function getChannelSubscriptions(decimal userId, string? direction = (), string? filter = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Channel[]|error {
-        string  path = string `/users/${userId}/channels`;
+        string resourcePath = string `/users/${userId}/channels`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Channel[] response = check self.clientEp-> get(path, targetType = ChannelArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Channel[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Check if a user follows a channel
@@ -2684,8 +2653,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The user follows the channel. 
     remote isolated function checkIfUserSubscribedToChannel(decimal channelId, decimal userId) returns http:Response|error {
-        string  path = string `/users/${userId}/channels/${channelId}`;
-        http:Response response = check self.clientEp-> get(path, targetType = http:Response);
+        string resourcePath = string `/users/${userId}/channels/${channelId}`;
+        http:Response response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Subscribe a user to a specific channel
@@ -2694,10 +2663,10 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The user is now a follower of the channel. 
     remote isolated function subscribeToChannel(decimal channelId, decimal userId) returns http:Response|error {
-        string  path = string `/users/${userId}/channels/${channelId}`;
+        string resourcePath = string `/users/${userId}/channels/${channelId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Unsubscribe a user from a specific channel
@@ -2706,8 +2675,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The user is no longer a follower of the channel. 
     remote isolated function unsubscribeFromChannel(decimal channelId, decimal userId) returns http:Response|error {
-        string  path = string `/users/${userId}/channels/${channelId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/users/${userId}/channels/${channelId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the custom logos that belong to a user
@@ -2715,8 +2684,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The custom logos were returned. 
     remote isolated function getCustomLogos(decimal userId) returns Picture[]|error {
-        string  path = string `/users/${userId}/customlogos`;
-        Picture[] response = check self.clientEp-> get(path, targetType = PictureArr);
+        string resourcePath = string `/users/${userId}/customlogos`;
+        Picture[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a custom logo
@@ -2724,10 +2693,10 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The custom logo was created. 
     remote isolated function createCustomLogo(decimal userId) returns Picture|error {
-        string  path = string `/users/${userId}/customlogos`;
+        string resourcePath = string `/users/${userId}/customlogos`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        Picture response = check self.clientEp-> post(path, request, targetType = Picture);
+        Picture response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     # Get a specific custom logo
@@ -2736,8 +2705,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The custom logo was returned. 
     remote isolated function getCustomLogo(decimal logoId, decimal userId) returns Picture|error {
-        string  path = string `/users/${userId}/customlogos/${logoId}`;
-        Picture response = check self.clientEp-> get(path, targetType = Picture);
+        string resourcePath = string `/users/${userId}/customlogos/${logoId}`;
+        Picture response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all videos in a user's feed
@@ -2749,10 +2718,10 @@ public isolated client class Client {
     # + 'type - The feed type. 
     # + return - The videos were returned. 
     remote isolated function getFeed(decimal userId, string? offset = (), decimal? page = (), decimal? perPage = (), string? 'type = ()) returns Activity31[]|error {
-        string  path = string `/users/${userId}/feed`;
+        string resourcePath = string `/users/${userId}/feed`;
         map<anydata> queryParam = {"offset": offset, "page": page, "per_page": perPage, "type": 'type};
-        path = path + check getPathForQueryParam(queryParam);
-        Activity31[] response = check self.clientEp-> get(path, targetType = Activity31Arr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Activity31[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the followers of a user
@@ -2765,10 +2734,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The user's followers were returned. 
     remote isolated function getFollowers(decimal userId, string? direction = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns User[]|error {
-        string  path = string `/users/${userId}/followers`;
+        string resourcePath = string `/users/${userId}/followers`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        User[] response = check self.clientEp-> get(path, targetType = UserArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        User[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the users that a user is following
@@ -2782,22 +2751,22 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The followed users were returned. 
     remote isolated function getUserFollowing(decimal userId, string? direction = (), string? filter = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns User[]|error {
-        string  path = string `/users/${userId}/following`;
+        string resourcePath = string `/users/${userId}/following`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        User[] response = check self.clientEp-> get(path, targetType = UserArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        User[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Follow a list of users
     #
     # + userId - The ID of the user. 
     # + return - The users were followed. 
-    remote isolated function followUsers(decimal userId, Body44 payload) returns http:Response|error {
-        string  path = string `/users/${userId}/following`;
+    remote isolated function followUsers(decimal userId, UserIdFollowingBody payload) returns http:Response|error {
+        string resourcePath = string `/users/${userId}/following`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        http:Response response = check self.clientEp->post(path, request, targetType=http:Response);
+        request.setPayload(jsonBody, "application/json");
+        http:Response response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Check if a user is following another user
@@ -2806,8 +2775,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The authenticated user follows the user in question. 
     remote isolated function checkIfUserIsFollowing(decimal followUserId, decimal userId) returns http:Response|error {
-        string  path = string `/users/${userId}/following/${followUserId}`;
-        http:Response response = check self.clientEp-> get(path, targetType = http:Response);
+        string resourcePath = string `/users/${userId}/following/${followUserId}`;
+        http:Response response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Follow a specific user
@@ -2816,10 +2785,10 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The user was followed. 
     remote isolated function followUser(decimal followUserId, decimal userId) returns http:Response|error {
-        string  path = string `/users/${userId}/following/${followUserId}`;
+        string resourcePath = string `/users/${userId}/following/${followUserId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Unfollow a user
@@ -2828,8 +2797,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The user was unfollowed. 
     remote isolated function unfollowUser(decimal followUserId, decimal userId) returns http:Response|error {
-        string  path = string `/users/${userId}/following/${followUserId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/users/${userId}/following/${followUserId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the groups that a user has joined
@@ -2843,10 +2812,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The groups were returned. 
     remote isolated function getUserGroups(decimal userId, string? direction = (), string? filter = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Group[]|error {
-        string  path = string `/users/${userId}/groups`;
+        string resourcePath = string `/users/${userId}/groups`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Group[] response = check self.clientEp-> get(path, targetType = GroupArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Group[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Check if a user has joined a group
@@ -2855,8 +2824,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The user has joined the group. 
     remote isolated function checkIfUserJoinedGroup(decimal groupId, decimal userId) returns http:Response|error {
-        string  path = string `/users/${userId}/groups/${groupId}`;
-        http:Response response = check self.clientEp-> get(path, targetType = http:Response);
+        string resourcePath = string `/users/${userId}/groups/${groupId}`;
+        http:Response response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a user to a group
@@ -2865,10 +2834,10 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The user joined the group. 
     remote isolated function joinGroup(decimal groupId, decimal userId) returns http:Response|error {
-        string  path = string `/users/${userId}/groups/${groupId}`;
+        string resourcePath = string `/users/${userId}/groups/${groupId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Remove a user from a group
@@ -2877,8 +2846,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The user left the group. 
     remote isolated function leaveGroup(decimal groupId, decimal userId) returns http:Response|error {
-        string  path = string `/users/${userId}/groups/${groupId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/users/${userId}/groups/${groupId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the videos that a user has liked
@@ -2892,10 +2861,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The videos were returned. 
     remote isolated function getLikes(decimal userId, string? filter = (), boolean? filterEmbeddable = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Video[]|error {
-        string  path = string `/users/${userId}/likes`;
+        string resourcePath = string `/users/${userId}/likes`;
         map<anydata> queryParam = {"filter": filter, "filter_embeddable": filterEmbeddable, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Check if a user has liked a video
@@ -2904,8 +2873,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The user has liked the video. 
     remote isolated function checkIfUserLikedVideo(decimal userId, decimal videoId) returns http:Response|error {
-        string  path = string `/users/${userId}/likes/${videoId}`;
-        http:Response response = check self.clientEp-> get(path, targetType = http:Response);
+        string resourcePath = string `/users/${userId}/likes/${videoId}`;
+        http:Response response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Cause a user to like a video
@@ -2914,10 +2883,10 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was liked. 
     remote isolated function likeVideo(decimal userId, decimal videoId) returns http:Response|error {
-        string  path = string `/users/${userId}/likes/${videoId}`;
+        string resourcePath = string `/users/${userId}/likes/${videoId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Cause a user to unlike a video
@@ -2926,8 +2895,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was unliked. 
     remote isolated function unlikeVideo(decimal userId, decimal videoId) returns http:Response|error {
-        string  path = string `/users/${userId}/likes/${videoId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/users/${userId}/likes/${videoId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the On Demand pages of a user
@@ -2940,22 +2909,22 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The On Demand pages were returned. 
     remote isolated function getUserVods(decimal userId, string? direction = (), string? filter = (), decimal? page = (), decimal? perPage = (), string? sort = ()) returns OnDemandPage[]|error {
-        string  path = string `/users/${userId}/ondemand/pages`;
+        string resourcePath = string `/users/${userId}/ondemand/pages`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "page": page, "per_page": perPage, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        OnDemandPage[] response = check self.clientEp-> get(path, targetType = OnDemandPageArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        OnDemandPage[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Create an On Demand page
     #
     # + userId - The ID of the user. 
     # + return - The On Demand page was created. 
-    remote isolated function createVod(decimal userId, Body45 payload) returns OnDemandPage|error {
-        string  path = string `/users/${userId}/ondemand/pages`;
+    remote isolated function createVod(decimal userId, OndemandPagesBody1 payload) returns OnDemandPage|error {
+        string resourcePath = string `/users/${userId}/ondemand/pages`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        OnDemandPage response = check self.clientEp->post(path, request, targetType=OnDemandPage);
+        request.setPayload(jsonBody, "application/json");
+        OnDemandPage response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Check if a user has made a purchase or rental from an On Demand page
@@ -2963,8 +2932,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - You have purchased the On Demand page. 
     remote isolated function checkIfVodWasPurchased(decimal userId) returns OnDemandPage|error {
-        string  path = string `/users/${userId}/ondemand/purchases`;
-        OnDemandPage response = check self.clientEp-> get(path, targetType = OnDemandPage);
+        string resourcePath = string `/users/${userId}/ondemand/purchases`;
+        OnDemandPage response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the pictures that belong to a user
@@ -2974,10 +2943,10 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The pictures were returned. 
     remote isolated function getPictures(decimal userId, decimal? page = (), decimal? perPage = ()) returns Picture[]|error {
-        string  path = string `/users/${userId}/pictures`;
+        string resourcePath = string `/users/${userId}/pictures`;
         map<anydata> queryParam = {"page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        Picture[] response = check self.clientEp-> get(path, targetType = PictureArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Picture[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a user picture
@@ -2985,10 +2954,10 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The user picture was created. 
     remote isolated function createPicture(decimal userId) returns Picture|error {
-        string  path = string `/users/${userId}/pictures`;
+        string resourcePath = string `/users/${userId}/pictures`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        Picture response = check self.clientEp-> post(path, request, targetType = Picture);
+        Picture response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     # Get a specific user picture
@@ -2997,8 +2966,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The picture was returned. 
     remote isolated function getPicture(decimal portraitsetId, decimal userId) returns Picture|error {
-        string  path = string `/users/${userId}/pictures/${portraitsetId}`;
-        Picture response = check self.clientEp-> get(path, targetType = Picture);
+        string resourcePath = string `/users/${userId}/pictures/${portraitsetId}`;
+        Picture response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Delete a user picture
@@ -3007,8 +2976,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The picture was deleted. 
     remote isolated function deletePicture(decimal portraitsetId, decimal userId) returns http:Response|error {
-        string  path = string `/users/${userId}/pictures/${portraitsetId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/users/${userId}/pictures/${portraitsetId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Edit a user picture
@@ -3016,12 +2985,11 @@ public isolated client class Client {
     # + portraitsetId - The ID of the picture. 
     # + userId - The ID of the user. 
     # + return - The picture was edited. 
-    remote isolated function editPicture(decimal portraitsetId, decimal userId, Body46 payload) returns Picture|error {
-        string  path = string `/users/${userId}/pictures/${portraitsetId}`;
+    remote isolated function editPicture(decimal portraitsetId, decimal userId, byte[] payload) returns Picture|error {
+        string resourcePath = string `/users/${userId}/pictures/${portraitsetId}`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Picture response = check self.clientEp->patch(path, request, targetType=Picture);
+        request.setPayload(payload, "application/vnd.vimeo.picture+json");
+        Picture response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Get all the portfolios that belong to a user
@@ -3034,10 +3002,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The portfolios were returned. 
     remote isolated function getPortfolios(decimal userId, string? direction = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Portfolio[]|error {
-        string  path = string `/users/${userId}/portfolios`;
+        string resourcePath = string `/users/${userId}/portfolios`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Portfolio[] response = check self.clientEp-> get(path, targetType = PortfolioArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Portfolio[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get a specific portfolio
@@ -3046,8 +3014,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The portfolio was returned. 
     remote isolated function getPortfolio(decimal portfolioId, decimal userId) returns Portfolio|error {
-        string  path = string `/users/${userId}/portfolios/${portfolioId}`;
-        Portfolio response = check self.clientEp-> get(path, targetType = Portfolio);
+        string resourcePath = string `/users/${userId}/portfolios/${portfolioId}`;
+        Portfolio response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the videos in a portfolio
@@ -3062,10 +3030,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. Option descriptions:  * `default` - This will sort to the default sort set on the portfolio. 
     # + return - The videos were returned. 
     remote isolated function getPortfolioVideos(decimal portfolioId, decimal userId, string? containingUri = (), string? filter = (), boolean? filterEmbeddable = (), decimal? page = (), decimal? perPage = (), string? sort = ()) returns Video[]|error {
-        string  path = string `/users/${userId}/portfolios/${portfolioId}/videos`;
+        string resourcePath = string `/users/${userId}/portfolios/${portfolioId}/videos`;
         map<anydata> queryParam = {"containing_uri": containingUri, "filter": filter, "filter_embeddable": filterEmbeddable, "page": page, "per_page": perPage, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get a specific video in a portfolio
@@ -3075,8 +3043,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was returned. 
     remote isolated function getPortfolioVideo(decimal portfolioId, decimal userId, decimal videoId) returns Video|error {
-        string  path = string `/users/${userId}/portfolios/${portfolioId}/videos/${videoId}`;
-        Video response = check self.clientEp-> get(path, targetType = Video);
+        string resourcePath = string `/users/${userId}/portfolios/${portfolioId}/videos/${videoId}`;
+        Video response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a video to a portfolio
@@ -3086,10 +3054,10 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was added. 
     remote isolated function addVideoToPortfolio(decimal portfolioId, decimal userId, decimal videoId) returns http:Response|error {
-        string  path = string `/users/${userId}/portfolios/${portfolioId}/videos/${videoId}`;
+        string resourcePath = string `/users/${userId}/portfolios/${portfolioId}/videos/${videoId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Remove a video from a portfolio
@@ -3099,8 +3067,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was deleted. 
     remote isolated function deleteVideoFromPortfolio(decimal portfolioId, decimal userId, decimal videoId) returns http:Response|error {
-        string  path = string `/users/${userId}/portfolios/${portfolioId}/videos/${videoId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/users/${userId}/portfolios/${portfolioId}/videos/${videoId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the embed presets that a user has created
@@ -3110,10 +3078,10 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The embed presets were returned. 
     remote isolated function getEmbedPresets(decimal userId, decimal? page = (), decimal? perPage = ()) returns Presets[]|error {
-        string  path = string `/users/${userId}/presets`;
+        string resourcePath = string `/users/${userId}/presets`;
         map<anydata> queryParam = {"page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        Presets[] response = check self.clientEp-> get(path, targetType = PresetsArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Presets[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get a specific embed preset
@@ -3122,8 +3090,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The embed preset was returned. 
     remote isolated function getEmbedPreset(decimal presetId, decimal userId) returns Presets|error {
-        string  path = string `/users/${userId}/presets/${presetId}`;
-        Presets response = check self.clientEp-> get(path, targetType = Presets);
+        string resourcePath = string `/users/${userId}/presets/${presetId}`;
+        Presets response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Edit an embed preset
@@ -3131,12 +3099,11 @@ public isolated client class Client {
     # + presetId - The ID of the preset. 
     # + userId - The ID of the user. 
     # + return - The embed preset was edited. 
-    remote isolated function editEmbedPreset(decimal presetId, decimal userId, Body47 payload) returns Presets|error {
-        string  path = string `/users/${userId}/presets/${presetId}`;
+    remote isolated function editEmbedPreset(decimal presetId, decimal userId, byte[] payload) returns Presets|error {
+        string resourcePath = string `/users/${userId}/presets/${presetId}`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Presets response = check self.clientEp->patch(path, request, targetType=Presets);
+        request.setPayload(payload, "application/vnd.vimeo.preset+json");
+        Presets response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Get all the videos that have been added to an embed preset
@@ -3147,10 +3114,10 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The videos were returned. 
     remote isolated function getEmbedPresetVideos(decimal presetId, decimal userId, decimal? page = (), decimal? perPage = ()) returns Video[]|error {
-        string  path = string `/users/${userId}/presets/${presetId}/videos`;
+        string resourcePath = string `/users/${userId}/presets/${presetId}/videos`;
         map<anydata> queryParam = {"page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the projects that belong to a user
@@ -3162,22 +3129,22 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The projects were returned. 
     remote isolated function getProjects(decimal userId, string? direction = (), decimal? page = (), decimal? perPage = (), string? sort = ()) returns Project[]|error {
-        string  path = string `/users/${userId}/projects`;
+        string resourcePath = string `/users/${userId}/projects`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Project[] response = check self.clientEp-> get(path, targetType = ProjectArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Project[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Create a project
     #
     # + userId - The ID of the user. 
     # + return - The project was created. 
-    remote isolated function createProject(decimal userId, Body48 payload) returns Project|error {
-        string  path = string `/users/${userId}/projects`;
+    remote isolated function createProject(decimal userId, UserIdProjectsBody payload) returns Project|error {
+        string resourcePath = string `/users/${userId}/projects`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Project response = check self.clientEp->post(path, request, targetType=Project);
+        request.setPayload(jsonBody, "application/json");
+        Project response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Get a specific project
@@ -3186,8 +3153,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The project was returned. 
     remote isolated function getProject(decimal projectId, decimal userId) returns Project|error {
-        string  path = string `/users/${userId}/projects/${projectId}`;
-        Project response = check self.clientEp-> get(path, targetType = Project);
+        string resourcePath = string `/users/${userId}/projects/${projectId}`;
+        Project response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Delete a project
@@ -3197,10 +3164,10 @@ public isolated client class Client {
     # + shouldDeleteClips - Whether to delete all the videos in the project along with the project itself. 
     # + return - The project was deleted. 
     remote isolated function deleteProject(decimal projectId, decimal userId, boolean? shouldDeleteClips = ()) returns http:Response|error {
-        string  path = string `/users/${userId}/projects/${projectId}`;
+        string resourcePath = string `/users/${userId}/projects/${projectId}`;
         map<anydata> queryParam = {"should_delete_clips": shouldDeleteClips};
-        path = path + check getPathForQueryParam(queryParam);
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Edit a project
@@ -3208,12 +3175,12 @@ public isolated client class Client {
     # + projectId - The ID of the project. 
     # + userId - The ID of the user. 
     # + return - The project was edited. 
-    remote isolated function editProject(decimal projectId, decimal userId, Body49 payload) returns Project|error {
-        string  path = string `/users/${userId}/projects/${projectId}`;
+    remote isolated function editProject(decimal projectId, decimal userId, ProjectsProjectIdBody1 payload) returns Project|error {
+        string resourcePath = string `/users/${userId}/projects/${projectId}`;
         http:Request request = new;
         json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Project response = check self.clientEp->patch(path, request, targetType=Project);
+        request.setPayload(jsonBody, "application/json");
+        Project response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Get all the videos in a project
@@ -3226,10 +3193,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The videos were returned. 
     remote isolated function getProjectVideos(decimal projectId, decimal userId, string? direction = (), decimal? page = (), decimal? perPage = (), string? sort = ()) returns Video[]|error {
-        string  path = string `/users/${userId}/projects/${projectId}/videos`;
+        string resourcePath = string `/users/${userId}/projects/${projectId}/videos`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a list of videos to a project
@@ -3239,26 +3206,26 @@ public isolated client class Client {
     # + uris - A comma-separated list of video URIs to add. 
     # + return - The videos were added. 
     remote isolated function addVideosToProject(decimal projectId, decimal userId, string uris) returns http:Response|error {
-        string  path = string `/users/${userId}/projects/${projectId}/videos`;
+        string resourcePath = string `/users/${userId}/projects/${projectId}/videos`;
         map<anydata> queryParam = {"uris": uris};
-        path = path + check getPathForQueryParam(queryParam);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Remove a list of videos from a project
     #
     # + projectId - The ID of the project. 
     # + userId - The ID of the user. 
-    # + uris - A comma-separated list of the video URIs to remove. 
     # + shouldDeleteClips - Whether to delete the videos when removing them from the project. 
+    # + uris - A comma-separated list of the video URIs to remove. 
     # + return - The videos were removed. 
     remote isolated function removeVideosFromProject(decimal projectId, decimal userId, string uris, boolean? shouldDeleteClips = ()) returns http:Response|error {
-        string  path = string `/users/${userId}/projects/${projectId}/videos`;
+        string resourcePath = string `/users/${userId}/projects/${projectId}/videos`;
         map<anydata> queryParam = {"should_delete_clips": shouldDeleteClips, "uris": uris};
-        path = path + check getPathForQueryParam(queryParam);
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Add a specific video to a project
@@ -3268,10 +3235,10 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was added. 
     remote isolated function addVideoToProject(decimal projectId, decimal userId, decimal videoId) returns http:Response|error {
-        string  path = string `/users/${userId}/projects/${projectId}/videos/${videoId}`;
+        string resourcePath = string `/users/${userId}/projects/${projectId}/videos/${videoId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Remove a specific video from a project
@@ -3281,8 +3248,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was removed. 
     remote isolated function removeVideoFromProject(decimal projectId, decimal userId, decimal videoId) returns http:Response|error {
-        string  path = string `/users/${userId}/projects/${projectId}/videos/${videoId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/users/${userId}/projects/${projectId}/videos/${videoId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get a user's upload attempt
@@ -3291,8 +3258,8 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + return - The upload attempt was returned. 
     remote isolated function getUploadAttempt(decimal upload, decimal userId) returns UploadAttempt|error {
-        string  path = string `/users/${userId}/uploads/${upload}`;
-        UploadAttempt response = check self.clientEp-> get(path, targetType = UploadAttempt);
+        string resourcePath = string `/users/${userId}/uploads/${upload}`;
+        UploadAttempt response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Complete a user's streaming upload
@@ -3303,10 +3270,10 @@ public isolated client class Client {
     # + videoFileId - The ID of the uploaded file. 
     # + return - The streaming upload is complete. 
     remote isolated function completeStreamingUpload(decimal upload, decimal userId, string signature, decimal videoFileId) returns http:Response|error {
-        string  path = string `/users/${userId}/uploads/${upload}`;
+        string resourcePath = string `/users/${userId}/uploads/${upload}`;
         map<anydata> queryParam = {"signature": signature, "video_file_id": videoFileId};
-        path = path + check getPathForQueryParam(queryParam);
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the videos that a user has uploaded
@@ -3323,22 +3290,21 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The videos were returned. 
     remote isolated function getVideos(decimal userId, string? containingUri = (), string? direction = (), string? filter = (), boolean? filterEmbeddable = (), boolean? filterPlayable = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Video[]|error {
-        string  path = string `/users/${userId}/videos`;
+        string resourcePath = string `/users/${userId}/videos`;
         map<anydata> queryParam = {"containing_uri": containingUri, "direction": direction, "filter": filter, "filter_embeddable": filterEmbeddable, "filter_playable": filterPlayable, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Upload a video
     #
     # + userId - The ID of the user. 
     # + return - The upload procedure has begun. 
-    remote isolated function uploadVideo(decimal userId, Body50 payload) returns Video|error {
-        string  path = string `/users/${userId}/videos`;
+    remote isolated function uploadVideo(decimal userId, byte[] payload) returns Video|error {
+        string resourcePath = string `/users/${userId}/videos`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Video response = check self.clientEp->post(path, request, targetType=Video);
+        request.setPayload(payload, "application/vnd.vimeo.video+json");
+        Video response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Check if a user owns a video
@@ -3347,8 +3313,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The user owns the video. 
     remote isolated function checkIfUserOwnsVideo(decimal userId, decimal videoId) returns Video|error {
-        string  path = string `/users/${userId}/videos/${videoId}`;
-        Video response = check self.clientEp-> get(path, targetType = Video);
+        string resourcePath = string `/users/${userId}/videos/${videoId}`;
+        Video response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the videos in a user's Watch Later queue
@@ -3363,10 +3329,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The videos were returned. 
     remote isolated function getWatchLaterQueue(decimal userId, string? direction = (), string? filter = (), boolean? filterEmbeddable = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Video[]|error {
-        string  path = string `/users/${userId}/watchlater`;
+        string resourcePath = string `/users/${userId}/watchlater`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "filter_embeddable": filterEmbeddable, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Check if a user has added a specific video to their Watch Later queue
@@ -3375,8 +3341,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video appears in the user's Watch Later queue. 
     remote isolated function checkWatchLaterQueue(decimal userId, decimal videoId) returns Video|error {
-        string  path = string `/users/${userId}/watchlater/${videoId}`;
-        Video response = check self.clientEp-> get(path, targetType = Video);
+        string resourcePath = string `/users/${userId}/watchlater/${videoId}`;
+        Video response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a video to a user's Watch Later queue
@@ -3385,10 +3351,10 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was added. 
     remote isolated function addVideoToWatchLater(decimal userId, decimal videoId) returns http:Response|error {
-        string  path = string `/users/${userId}/watchlater/${videoId}`;
+        string resourcePath = string `/users/${userId}/watchlater/${videoId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Remove a video from a user's Watch Later queue
@@ -3397,26 +3363,26 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was deleted. 
     remote isolated function deleteVideoFromWatchLater(decimal userId, decimal videoId) returns http:Response|error {
-        string  path = string `/users/${userId}/watchlater/${videoId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/users/${userId}/watchlater/${videoId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Search for videos
     #
-    # + query - Search query. 
     # + direction - The sort direction of the results. 
     # + filter - The attribute by which to filter the results. `CC` and related filters target videos with the corresponding Creative Commons licenses. For more information, see our [Creative Commons](https://vimeo.com/creativecommons) page. 
     # + links - A comma-separated list of video URLs to find. 
     # + page - The page number of the results to show. 
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
+    # + query - Search query. 
     # + sort - The way to sort the results. 
     # + uris - The comma-separated list of videos to find. 
     # + return - The search results were returned. 
     remote isolated function searchVideos(string query, string? direction = (), string? filter = (), string? links = (), decimal? page = (), decimal? perPage = (), string? sort = (), string? uris = ()) returns Video[]|error {
-        string  path = string `/videos`;
+        string resourcePath = string `/videos`;
         map<anydata> queryParam = {"direction": direction, "filter": filter, "links": links, "page": page, "per_page": perPage, "query": query, "sort": sort, "uris": uris};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get a specific video
@@ -3424,8 +3390,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was returned. 
     remote isolated function getVideo(decimal videoId) returns Video|error {
-        string  path = string `/videos/${videoId}`;
-        Video response = check self.clientEp-> get(path, targetType = Video);
+        string resourcePath = string `/videos/${videoId}`;
+        Video response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Delete a video
@@ -3433,20 +3399,19 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was deleted. 
     remote isolated function deleteVideo(decimal videoId) returns http:Response|error {
-        string  path = string `/videos/${videoId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/videos/${videoId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Edit a video
     #
     # + videoId - The ID of the video. 
     # + return - The video was edited. 
-    remote isolated function editVideo(decimal videoId, Body51 payload) returns Video|error {
-        string  path = string `/videos/${videoId}`;
+    remote isolated function editVideo(decimal videoId, byte[] payload) returns Video|error {
+        string resourcePath = string `/videos/${videoId}`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Video response = check self.clientEp->patch(path, request, targetType=Video);
+        request.setPayload(payload, "application/vnd.vimeo.video+json");
+        Video response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Get all the channels to which a user can add or remove a specific video
@@ -3454,8 +3419,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The channels were returned. 
     remote isolated function getAvailableVideoChannels(decimal videoId) returns Channel[]|error {
-        string  path = string `/videos/${videoId}/available_channels`;
-        Channel[] response = check self.clientEp-> get(path, targetType = ChannelArr);
+        string resourcePath = string `/videos/${videoId}/available_channels`;
+        Channel[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the categories to which a video belongs
@@ -3463,20 +3428,19 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The categories were returned. 
     remote isolated function getVideoCategories(decimal videoId) returns Category[]|error {
-        string  path = string `/videos/${videoId}/categories`;
-        Category[] response = check self.clientEp-> get(path, targetType = CategoryArr);
+        string resourcePath = string `/videos/${videoId}/categories`;
+        Category[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Suggest categories for a video
     #
     # + videoId - The ID of the video. 
     # + return - The categories were suggested. 
-    remote isolated function suggestVideoCategory(decimal videoId, Body52 payload) returns Category|error {
-        string  path = string `/videos/${videoId}/categories`;
+    remote isolated function suggestVideoCategory(decimal videoId, byte[] payload) returns Category|error {
+        string resourcePath = string `/videos/${videoId}/categories`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Category response = check self.clientEp->put(path, request, targetType=Category);
+        request.setPayload(payload, "application/vnd.vimeo.category+json");
+        Category response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     # Get all the comments on a video
@@ -3487,22 +3451,21 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The comments were returned. 
     remote isolated function getComments(decimal videoId, string? direction = (), decimal? page = (), decimal? perPage = ()) returns Comment[]|error {
-        string  path = string `/videos/${videoId}/comments`;
+        string resourcePath = string `/videos/${videoId}/comments`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        Comment[] response = check self.clientEp-> get(path, targetType = CommentArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Comment[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a comment to a video
     #
     # + videoId - The ID of the video. 
     # + return - The comment was added. 
-    remote isolated function createComment(decimal videoId, Body53 payload) returns Comment|error {
-        string  path = string `/videos/${videoId}/comments`;
+    remote isolated function createComment(decimal videoId, byte[] payload) returns Comment|error {
+        string resourcePath = string `/videos/${videoId}/comments`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Comment response = check self.clientEp->post(path, request, targetType=Comment);
+        request.setPayload(payload, "application/vnd.vimeo.comment+json");
+        Comment response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Get a specific video comment
@@ -3511,8 +3474,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The comment was returned. 
     remote isolated function getComment(decimal commentId, decimal videoId) returns Comment|error {
-        string  path = string `/videos/${videoId}/comments/${commentId}`;
-        Comment response = check self.clientEp-> get(path, targetType = Comment);
+        string resourcePath = string `/videos/${videoId}/comments/${commentId}`;
+        Comment response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Delete a video comment
@@ -3521,8 +3484,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The comment was deleted. 
     remote isolated function deleteComment(decimal commentId, decimal videoId) returns http:Response|error {
-        string  path = string `/videos/${videoId}/comments/${commentId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/videos/${videoId}/comments/${commentId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Edit a video comment
@@ -3530,12 +3493,11 @@ public isolated client class Client {
     # + commentId - The ID of the comment. 
     # + videoId - The ID of the video. 
     # + return - The comment was edited. 
-    remote isolated function editComment(decimal commentId, decimal videoId, Body54 payload) returns Comment|error {
-        string  path = string `/videos/${videoId}/comments/${commentId}`;
+    remote isolated function editComment(decimal commentId, decimal videoId, byte[] payload) returns Comment|error {
+        string resourcePath = string `/videos/${videoId}/comments/${commentId}`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Comment response = check self.clientEp->patch(path, request, targetType=Comment);
+        request.setPayload(payload, "application/vnd.vimeo.comment+json");
+        Comment response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Get all the replies to a video comment
@@ -3546,10 +3508,10 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The replies were returned. 
     remote isolated function getCommentReplies(decimal commentId, decimal videoId, decimal? page = (), decimal? perPage = ()) returns Comment[]|error {
-        string  path = string `/videos/${videoId}/comments/${commentId}/replies`;
+        string resourcePath = string `/videos/${videoId}/comments/${commentId}/replies`;
         map<anydata> queryParam = {"page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        Comment[] response = check self.clientEp-> get(path, targetType = CommentArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Comment[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a reply to a video comment
@@ -3557,12 +3519,11 @@ public isolated client class Client {
     # + commentId - The ID of the comment. 
     # + videoId - The ID of the video. 
     # + return - The reply was added. 
-    remote isolated function createCommentReply(decimal commentId, decimal videoId, Body55 payload) returns Comment|error {
-        string  path = string `/videos/${videoId}/comments/${commentId}/replies`;
+    remote isolated function createCommentReply(decimal commentId, decimal videoId, byte[] payload) returns Comment|error {
+        string resourcePath = string `/videos/${videoId}/comments/${commentId}/replies`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Comment response = check self.clientEp->post(path, request, targetType=Comment);
+        request.setPayload(payload, "application/vnd.vimeo.comment+json");
+        Comment response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Get all the credited users in a video
@@ -3575,22 +3536,21 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The users were returned. 
     remote isolated function getVideoCredits(decimal videoId, string? direction = (), decimal? page = (), decimal? perPage = (), string? query = (), string? sort = ()) returns Credit[]|error {
-        string  path = string `/videos/${videoId}/credits`;
+        string resourcePath = string `/videos/${videoId}/credits`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "query": query, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        Credit[] response = check self.clientEp-> get(path, targetType = CreditArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Credit[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Credit a user in a video
     #
     # + videoId - The ID of the video. 
     # + return - The credit was added. 
-    remote isolated function addVideoCredit(decimal videoId, Body56 payload) returns Credit|error {
-        string  path = string `/videos/${videoId}/credits`;
+    remote isolated function addVideoCredit(decimal videoId, byte[] payload) returns Credit|error {
+        string resourcePath = string `/videos/${videoId}/credits`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Credit response = check self.clientEp->post(path, request, targetType=Credit);
+        request.setPayload(payload, "application/vnd.vimeo.credit+json");
+        Credit response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Get a specific credited user in a video
@@ -3599,8 +3559,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The credit was returned. 
     remote isolated function getVideoCredit(decimal creditId, decimal videoId) returns Credit|error {
-        string  path = string `/videos/${videoId}/credits/${creditId}`;
-        Credit response = check self.clientEp-> get(path, targetType = Credit);
+        string resourcePath = string `/videos/${videoId}/credits/${creditId}`;
+        Credit response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Delete a credit for a user in a video
@@ -3609,8 +3569,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The credit was deleted. 
     remote isolated function deleteVideoCredit(decimal creditId, decimal videoId) returns http:Response|error {
-        string  path = string `/videos/${videoId}/credits/${creditId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/videos/${videoId}/credits/${creditId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Edit a credit for a user in a video
@@ -3618,12 +3578,11 @@ public isolated client class Client {
     # + creditId - The ID of the credit. 
     # + videoId - The ID of the video. 
     # + return - The credit was edited. 
-    remote isolated function editVideoCredit(decimal creditId, decimal videoId, Body57 payload) returns Credit|error {
-        string  path = string `/videos/${videoId}/credits/${creditId}`;
+    remote isolated function editVideoCredit(decimal creditId, decimal videoId, byte[] payload) returns Credit|error {
+        string resourcePath = string `/videos/${videoId}/credits/${creditId}`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Credit response = check self.clientEp->patch(path, request, targetType=Credit);
+        request.setPayload(payload, "application/vnd.vimeo.credit+json");
+        Credit response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Get all the users who have liked a video
@@ -3635,10 +3594,10 @@ public isolated client class Client {
     # + sort - The way to sort the results. 
     # + return - The users were returned. 
     remote isolated function getVideoLikes(decimal videoId, string? direction = (), decimal? page = (), decimal? perPage = (), string? sort = ()) returns User[]|error {
-        string  path = string `/videos/${videoId}/likes`;
+        string resourcePath = string `/videos/${videoId}/likes`;
         map<anydata> queryParam = {"direction": direction, "page": page, "per_page": perPage, "sort": sort};
-        path = path + check getPathForQueryParam(queryParam);
-        User[] response = check self.clientEp-> get(path, targetType = UserArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        User[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Get all the thumbnails of a video
@@ -3648,22 +3607,21 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The thumbnails were returned. 
     remote isolated function getVideoThumbnails(decimal videoId, decimal? page = (), decimal? perPage = ()) returns Picture[]|error {
-        string  path = string `/videos/${videoId}/pictures`;
+        string resourcePath = string `/videos/${videoId}/pictures`;
         map<anydata> queryParam = {"page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        Picture[] response = check self.clientEp-> get(path, targetType = PictureArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Picture[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a video thumbnail
     #
     # + videoId - The ID of the video. 
     # + return - The thumbnail was created. 
-    remote isolated function createVideoThumbnail(decimal videoId, Body58 payload) returns Picture|error {
-        string  path = string `/videos/${videoId}/pictures`;
+    remote isolated function createVideoThumbnail(decimal videoId, byte[] payload) returns Picture|error {
+        string resourcePath = string `/videos/${videoId}/pictures`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Picture response = check self.clientEp->post(path, request, targetType=Picture);
+        request.setPayload(payload, "application/vnd.vimeo.picture+json");
+        Picture response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Get a video thumbnail
@@ -3672,8 +3630,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The thumbnail was returned. 
     remote isolated function getVideoThumbnail(decimal pictureId, decimal videoId) returns Picture|error {
-        string  path = string `/videos/${videoId}/pictures/${pictureId}`;
-        Picture response = check self.clientEp-> get(path, targetType = Picture);
+        string resourcePath = string `/videos/${videoId}/pictures/${pictureId}`;
+        Picture response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Delete a video thumbnail
@@ -3682,8 +3640,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The thumbnail was deleted. 
     remote isolated function deleteVideoThumbnail(decimal pictureId, decimal videoId) returns http:Response|error {
-        string  path = string `/videos/${videoId}/pictures/${pictureId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/videos/${videoId}/pictures/${pictureId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Edit a video thumbnail
@@ -3691,12 +3649,11 @@ public isolated client class Client {
     # + pictureId - The ID of the picture. 
     # + videoId - The ID of the video. 
     # + return - The thumbnail was edited. 
-    remote isolated function editVideoThumbnail(decimal pictureId, decimal videoId, Body59 payload) returns Picture|error {
-        string  path = string `/videos/${videoId}/pictures/${pictureId}`;
+    remote isolated function editVideoThumbnail(decimal pictureId, decimal videoId, byte[] payload) returns Picture|error {
+        string resourcePath = string `/videos/${videoId}/pictures/${pictureId}`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Picture response = check self.clientEp->patch(path, request, targetType=Picture);
+        request.setPayload(payload, "application/vnd.vimeo.picture+json");
+        Picture response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Check if an embed preset has been added to a video
@@ -3705,8 +3662,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The embed presets exists. 
     remote isolated function getVideoEmbedPreset(decimal presetId, decimal videoId) returns http:Response|error {
-        string  path = string `/videos/${videoId}/presets/${presetId}`;
-        http:Response response = check self.clientEp-> get(path, targetType = http:Response);
+        string resourcePath = string `/videos/${videoId}/presets/${presetId}`;
+        http:Response response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add an embed preset to a video
@@ -3715,10 +3672,10 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The embed preset was assigned. 
     remote isolated function addVideoEmbedPreset(decimal presetId, decimal videoId) returns http:Response|error {
-        string  path = string `/videos/${videoId}/presets/${presetId}`;
+        string resourcePath = string `/videos/${videoId}/presets/${presetId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Remove an embed preset from a video
@@ -3727,8 +3684,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The embed preset was unassigned. 
     remote isolated function deleteVideoEmbedPreset(decimal presetId, decimal videoId) returns http:Response|error {
-        string  path = string `/videos/${videoId}/presets/${presetId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/videos/${videoId}/presets/${presetId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the domains on which a video can be embedded
@@ -3738,10 +3695,10 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The domains were returned. 
     remote isolated function getVideoPrivacyDomains(decimal videoId, decimal? page = (), decimal? perPage = ()) returns Domain[]|error {
-        string  path = string `/videos/${videoId}/privacy/domains`;
+        string resourcePath = string `/videos/${videoId}/privacy/domains`;
         map<anydata> queryParam = {"page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        Domain[] response = check self.clientEp-> get(path, targetType = DomainArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Domain[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Permit a video to be embedded on a domain
@@ -3750,10 +3707,10 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video is now embeddable on the domain. 
     remote isolated function addVideoPrivacyDomain(string domain, decimal videoId) returns http:Response|error {
-        string  path = string `/videos/${videoId}/privacy/domains/${domain}`;
+        string resourcePath = string `/videos/${videoId}/privacy/domains/${domain}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        http:Response response = check self.clientEp-> put(path, request, targetType = http:Response);
+        http:Response response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Restrict a video from being embedded on a domain
@@ -3762,8 +3719,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The video was disallowed from being embedded on the domain. 
     remote isolated function deleteVideoPrivacyDomain(string domain, decimal videoId) returns http:Response|error {
-        string  path = string `/videos/${videoId}/privacy/domains/${domain}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/videos/${videoId}/privacy/domains/${domain}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the users who can view a user's private videos by default
@@ -3773,10 +3730,10 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The users were returned. 
     remote isolated function getVideoPrivacyUsers(decimal videoId, decimal? page = (), decimal? perPage = ()) returns User[]|error {
-        string  path = string `/videos/${videoId}/privacy/users`;
+        string resourcePath = string `/videos/${videoId}/privacy/users`;
         map<anydata> queryParam = {"page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        User[] response = check self.clientEp-> get(path, targetType = UserArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        User[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Permit a list of users to view a private video
@@ -3784,10 +3741,10 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The users can now view the private video. 
     remote isolated function addVideoPrivacyUsers(decimal videoId) returns User[]|error {
-        string  path = string `/videos/${videoId}/privacy/users`;
+        string resourcePath = string `/videos/${videoId}/privacy/users`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        User[] response = check self.clientEp-> put(path, request, targetType = UserArr);
+        User[] response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Permit a specific user to view a private video
@@ -3795,11 +3752,11 @@ public isolated client class Client {
     # + userId - The ID of the user. 
     # + videoId - The ID of the video. 
     # + return - The user can now view the private video. 
-    remote isolated function addVideoPrivacyUser(decimal userId, decimal videoId) returns User|error {
-        string  path = string `/videos/${videoId}/privacy/users/${userId}`;
+    remote isolated function addVideoPrivacyUser(decimal userId, decimal videoId) returns User|error? {
+        string resourcePath = string `/videos/${videoId}/privacy/users/${userId}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        User response = check self.clientEp-> put(path, request, targetType = User);
+        User? response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Restrict a user from viewing a private video
@@ -3808,8 +3765,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The user was disallowed from viewing the private video. 
     remote isolated function deleteVideoPrivacyUser(decimal userId, decimal videoId) returns http:Response|error {
-        string  path = string `/videos/${videoId}/privacy/users/${userId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/videos/${videoId}/privacy/users/${userId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the tags of a video
@@ -3817,20 +3774,19 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The tags were returned. 
     remote isolated function getVideoTags(decimal videoId) returns Tag[]|error {
-        string  path = string `/videos/${videoId}/tags`;
-        Tag[] response = check self.clientEp-> get(path, targetType = TagArr);
+        string resourcePath = string `/videos/${videoId}/tags`;
+        Tag[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a list of tags to a video
     #
     # + videoId - The ID of the video. 
     # + return - The tags that were added. 
-    remote isolated function addVideoTags(decimal videoId, Body60 payload) returns Tag[]|error {
-        string  path = string `/videos/${videoId}/tags`;
+    remote isolated function addVideoTags(decimal videoId, byte[] payload) returns Tag[]|error {
+        string resourcePath = string `/videos/${videoId}/tags`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        Tag[] response = check self.clientEp->put(path, request, targetType=TagArr);
+        request.setPayload(payload, "application/vnd.vimeo.tag+json");
+        Tag[] response = check self.clientEp->put(resourcePath, request);
         return response;
     }
     # Check if a tag has been added to a video
@@ -3839,8 +3795,8 @@ public isolated client class Client {
     # + word - The tag word. 
     # + return - The tag has been added. 
     remote isolated function checkVideoForTag(decimal videoId, string word) returns Tag|error {
-        string  path = string `/videos/${videoId}/tags/${word}`;
-        Tag response = check self.clientEp-> get(path, targetType = Tag);
+        string resourcePath = string `/videos/${videoId}/tags/${word}`;
+        Tag response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a specific tag to a video
@@ -3849,10 +3805,10 @@ public isolated client class Client {
     # + word - The tag word. 
     # + return - The tag was added. 
     remote isolated function addVideoTag(decimal videoId, string word) returns Tag|error {
-        string  path = string `/videos/${videoId}/tags/${word}`;
+        string resourcePath = string `/videos/${videoId}/tags/${word}`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        Tag response = check self.clientEp-> put(path, request, targetType = Tag);
+        Tag response = check self.clientEp-> put(resourcePath, request);
         return response;
     }
     # Remove a tag from a video
@@ -3861,8 +3817,8 @@ public isolated client class Client {
     # + word - The tag word. 
     # + return - The tag was deleted. 
     remote isolated function deleteVideoTag(decimal videoId, string word) returns http:Response|error {
-        string  path = string `/videos/${videoId}/tags/${word}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/videos/${videoId}/tags/${word}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Get all the text tracks of a video
@@ -3870,20 +3826,19 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The text tracks were returned. 
     remote isolated function getTextTracks(decimal videoId) returns TextTrack[]|error {
-        string  path = string `/videos/${videoId}/texttracks`;
-        TextTrack[] response = check self.clientEp-> get(path, targetType = TextTrackArr);
+        string resourcePath = string `/videos/${videoId}/texttracks`;
+        TextTrack[] response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a text track to a video
     #
     # + videoId - The ID of the video. 
     # + return - The text track was added. 
-    remote isolated function createTextTrack(decimal videoId, Body61 payload) returns TextTrack|error {
-        string  path = string `/videos/${videoId}/texttracks`;
+    remote isolated function createTextTrack(decimal videoId, byte[] payload) returns TextTrack|error {
+        string resourcePath = string `/videos/${videoId}/texttracks`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        TextTrack response = check self.clientEp->post(path, request, targetType=TextTrack);
+        request.setPayload(payload, "application/vnd.vimeo.video.texttrack+json");
+        TextTrack response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Get a specific text track
@@ -3892,8 +3847,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The text track was returned. 
     remote isolated function getTextTrack(decimal texttrackId, decimal videoId) returns TextTrack|error {
-        string  path = string `/videos/${videoId}/texttracks/${texttrackId}`;
-        TextTrack response = check self.clientEp-> get(path, targetType = TextTrack);
+        string resourcePath = string `/videos/${videoId}/texttracks/${texttrackId}`;
+        TextTrack response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Delete a text track
@@ -3902,8 +3857,8 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The text track was deleted. 
     remote isolated function deleteTextTrack(decimal texttrackId, decimal videoId) returns http:Response|error {
-        string  path = string `/videos/${videoId}/texttracks/${texttrackId}`;
-        http:Response response = check self.clientEp-> delete(path, targetType = http:Response);
+        string resourcePath = string `/videos/${videoId}/texttracks/${texttrackId}`;
+        http:Response response = check self.clientEp->delete(resourcePath);
         return response;
     }
     # Edit a text track
@@ -3911,12 +3866,11 @@ public isolated client class Client {
     # + texttrackId - The ID of the text track. 
     # + videoId - The ID of the video. 
     # + return - The text track was edited. 
-    remote isolated function editTextTrack(decimal texttrackId, decimal videoId, Body62 payload) returns TextTrack|error {
-        string  path = string `/videos/${videoId}/texttracks/${texttrackId}`;
+    remote isolated function editTextTrack(decimal texttrackId, decimal videoId, byte[] payload) returns TextTrack|error {
+        string resourcePath = string `/videos/${videoId}/texttracks/${texttrackId}`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        TextTrack response = check self.clientEp->patch(path, request, targetType=TextTrack);
+        request.setPayload(payload, "application/vnd.vimeo.video.texttrack+json");
+        TextTrack response = check self.clientEp->patch(resourcePath, request);
         return response;
     }
     # Add a new custom logo to a video
@@ -3924,10 +3878,10 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - Standard request. 
     remote isolated function createVideoCustomLogo(decimal videoId) returns Picture|error {
-        string  path = string `/videos/${videoId}/timelinethumbnails`;
+        string resourcePath = string `/videos/${videoId}/timelinethumbnails`;
         http:Request request = new;
         //TODO: Update the request as needed;
-        Picture response = check self.clientEp-> post(path, request, targetType = Picture);
+        Picture response = check self.clientEp-> post(resourcePath, request);
         return response;
     }
     # Get a custom video logo
@@ -3936,20 +3890,19 @@ public isolated client class Client {
     # + videoId - The ID of the video. 
     # + return - The custom logo was returned. 
     remote isolated function getVideoCustomLogo(decimal thumbnailId, decimal videoId) returns Picture|error {
-        string  path = string `/videos/${videoId}/timelinethumbnails/${thumbnailId}`;
-        Picture response = check self.clientEp-> get(path, targetType = Picture);
+        string resourcePath = string `/videos/${videoId}/timelinethumbnails/${thumbnailId}`;
+        Picture response = check self.clientEp->get(resourcePath);
         return response;
     }
     # Add a version to a video
     #
     # + videoId - The ID of the video. 
     # + return - Standard request. 
-    remote isolated function createVideoVersion(decimal videoId, Body63 payload) returns VideoVersions|error {
-        string  path = string `/videos/${videoId}/versions`;
+    remote isolated function createVideoVersion(decimal videoId, byte[] payload) returns VideoVersions|error {
+        string resourcePath = string `/videos/${videoId}/versions`;
         http:Request request = new;
-        json jsonBody = check payload.cloneWithType(json);
-        request.setPayload(jsonBody);
-        VideoVersions response = check self.clientEp->post(path, request, targetType=VideoVersions);
+        request.setPayload(payload, "application/vnd.vimeo.video.version+json");
+        VideoVersions response = check self.clientEp->post(resourcePath, request);
         return response;
     }
     # Get all the related videos of a video
@@ -3960,44 +3913,10 @@ public isolated client class Client {
     # + perPage - The number of items to show on each page of results, up to a maximum of 100. 
     # + return - The related videos were returned. 
     remote isolated function getRelatedVideos(decimal videoId, string? filter = (), decimal? page = (), decimal? perPage = ()) returns Video[]|error {
-        string  path = string `/videos/${videoId}/videos`;
+        string resourcePath = string `/videos/${videoId}/videos`;
         map<anydata> queryParam = {"filter": filter, "page": page, "per_page": perPage};
-        path = path + check getPathForQueryParam(queryParam);
-        Video[] response = check self.clientEp-> get(path, targetType = VideoArr);
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam);
+        Video[] response = check self.clientEp->get(resourcePath);
         return response;
     }
-}
-
-# Generate query path with query parameter.
-#
-# + queryParam - Query parameter map 
-# + return - Returns generated Path or error at failure of client initialization 
-isolated function  getPathForQueryParam(map<anydata> queryParam)  returns  string|error {
-    string[] param = [];
-    param[param.length()] = "?";
-    foreach  var [key, value] in  queryParam.entries() {
-        if  value  is  () {
-            _ = queryParam.remove(key);
-        } else {
-            if  string:startsWith( key, "'") {
-                 param[param.length()] = string:substring(key, 1, key.length());
-            } else {
-                param[param.length()] = key;
-            }
-            param[param.length()] = "=";
-            if  value  is  string {
-                string updateV =  check url:encode(value, "UTF-8");
-                param[param.length()] = updateV;
-            } else {
-                param[param.length()] = value.toString();
-            }
-            param[param.length()] = "&";
-        }
-    }
-    _ = param.remove(param.length()-1);
-    if  param.length() ==  1 {
-        _ = param.remove(0);
-    }
-    string restOfPath = string:'join("", ...param);
-    return restOfPath;
 }

--- a/openapi/vimeo/openapi.yml
+++ b/openapi/vimeo/openapi.yml
@@ -909,19 +909,6 @@ paths:
           schema:
             example: 927
             type: number
-      requestBody:
-        content:
-          application/vnd.vimeo.user+json:
-            schema:
-              properties:
-                user_uri:
-                  description: The URI of a user to remove as a moderator.
-                  example: /users/152184
-                  type: string
-              required:
-                - user_uri
-              type: object
-        required: true
       responses:
         "204":
           content:
@@ -1748,19 +1735,6 @@ paths:
           schema:
             example: 927
             type: number
-      requestBody:
-        content:
-          application/json:
-            schema:
-              properties:
-                video_uri:
-                  description: The URI of a video to remove.
-                  example: /videos/258684937
-                  type: string
-              required:
-                - video_uri
-              type: object
-        required: true
       responses:
         "204":
           content:
@@ -8428,18 +8402,6 @@ paths:
           schema:
             example: 61326
             type: number
-      requestBody:
-        content:
-          application/vnd.vimeo.ondemand.region+json:
-            schema:
-              properties:
-                countries:
-                  description: An array of country codes.
-                  items:
-                    type: string
-                  type: array
-              type: object
-        required: false
       responses:
         "200":
           content:
@@ -21933,7 +21895,7 @@ components:
             stats: Access video stats
             upload: Upload videos
             video_files: Access video files belonging to members with a PRO subscription or higher
-          tokenUrl: /oauth/access_token
+          tokenUrl: https://api.vimeo.com/oauth/access_token
         clientCredentials:
           scopes:
             create: Create new albums, channels, and so on
@@ -21949,5 +21911,5 @@ components:
             stats: Access video stats
             upload: Upload videos
             video_files: Access video files belonging to members with a PRO subscription or higher
-          tokenUrl: /oauth/authorize/client
+          tokenUrl: https://api.vimeo.com/oauth/access_token
       type: oauth2

--- a/openapi/vimeo/types.bal
+++ b/openapi/vimeo/types.bal
@@ -136,7 +136,7 @@ public type VideoMetadataConnections record {
     # Information about the comments on this video.
     VideoMetadataConnectionsComments comments;
     # Information about the users credited in this video.
-    VideoMetadataConnectionsCredits credits;
+    VideoMetadataConnectionsCredits? credits;
     # Information about the users who have liked this video.
     VideoMetadataConnectionsLikes likes;
     # Information about this video's ondemand data.
@@ -146,9 +146,9 @@ public type VideoMetadataConnections record {
     # The DRM playback status connection for this video.
     VideoMetadataConnectionsPlayback playback;
     # The recommendations for this video.
-    VideoMetadataConnectionsRecommendations recommendations;
+    VideoMetadataConnectionsRecommendations? recommendations;
     # Related content for this video.
-    VideoMetadataConnectionsRelated related;
+    VideoMetadataConnectionsRelated? related;
     # Information about the video's season.
     VideoMetadataConnectionsSeason season;
     # Information about this video's text tracks.
@@ -369,6 +369,73 @@ public type MeondemandpagesEpisodesRentPrice record {
     decimal USD?;
 };
 
+public type OndemandPagesBody record {
+    # An array of accepted currencies.
+    # 
+    # Option descriptions:
+    #  * `AUD` - Australian Dollar
+    #  * `CAD` - Canadian Dollar
+    #  * `CHF` - Swiss Franc
+    #  * `DKK` - Danish Krone
+    #  * `EUR` - Euro
+    #  * `GBP` - British Pound
+    #  * `JPY` - Japanese Yen
+    #  * `KRW` - South Korean Won
+    #  * `NOK` - Norwegian Krone
+    #  * `PLN` - Polish Zloty
+    #  * `SEK` - Swedish Krona
+    #  * `USD` - US Dollar
+    string accepted_currencies?;
+    MeondemandpagesBuy buy?;
+    # One or more ratings, either as a comma-separated list or as a JSON array depending on the request format.
+    string content_rating;
+    # The description of the On Demand page.
+    string description;
+    # The custom domain of the On Demand page.
+    string domain_link?;
+    MeondemandpagesEpisodes episodes?;
+    # The custom string to use in this On Demand page's Vimeo URL.
+    string link?;
+    # The name of the On Demand page.
+    string name;
+    MeondemandpagesRent rent?;
+    MeondemandpagesSubscription subscription?;
+    # The type of On Demand page.
+    string 'type;
+};
+
+public type UserIdVideosBody record {
+    # A list of values describing the content in this video. Find the full list in the [/contentratings](https://developer.vimeo.com/api/endpoints/videos#GET/contentratings) endpoint.
+    string[] content_rating?;
+    # The description of the video.
+    string description?;
+    MevideosEmbed embed?;
+    # The Creative Commons license.
+    string license?;
+    # The video's default language. For a full list of valid languages, use the [/languages?filter=texttracks](https://developer.vimeo.com/api/endpoints/videos#GET/languages) endpoint.
+    string locale?;
+    # The title of the video.
+    string name?;
+    # The password. When you set `privacy.view` to `password`, you must provide the password as an additional parameter.
+    string password?;
+    MevideosPrivacy privacy?;
+    MevideosRatings ratings?;
+    MevideosReviewPage review_page?;
+    MevideosSpatial spatial?;
+    MevideosUpload upload;
+};
+
+public type VideoIdCreditsBody1 record {
+    # The email address of the credited person.
+    string email;
+    # The name of the credited person.
+    string name;
+    # The role of the credited person.
+    string role;
+    # The URI of the Vimeo user who should be given credit in this video.
+    string user_uri;
+};
+
 # Information about the channels related to this category.
 public type CategoryMetadataConnectionsChannels record {
     # An array of HTTP methods permitted on this URI.
@@ -384,7 +451,7 @@ public type ChannelMetadataInteractions record {
     # An action indicating that the authenticated user is the owner of the channel and may therefore add other users as channel moderators. This data requires a bearer token with the `private` scope.
     ChannelMetadataInteractionsAddModerators add_moderators;
     # When a channel appears in the context of adding or removing a video from it (`/videos/{video_id}/available_channels`), include information about adding or removing the video. This data requires a bearer token with the `private` scope.
-    ChannelMetadataInteractionsAddTo add_to;
+    ChannelMetadataInteractionsAddTo? add_to;
     # An action indicating if the authenticated user has followed this channel. This data requires a bearer token with the `private` scope.
     ChannelMetadataInteractionsFollow follow;
     # An action indicating that the authenticated user is a moderator of the channel and may therefore add or remove videos from the channel. This data requires a bearer token with the `private` scope.
@@ -474,6 +541,11 @@ public type OnDemandPromotion record {
     string uri;
 };
 
+public type ChannelIdModeratorsBody1 record {
+    # The URI of the user to add as a moderator.
+    string user_uri;
+};
+
 # Information about the albums created by this user.
 public type UserMetadataConnectionsAlbums record {
     # An array of HTTP methods permitted on this URI.
@@ -487,7 +559,7 @@ public type UserMetadataConnectionsAlbums record {
 # A list of resource URIs related to the activity.
 public type Activity31MetadataConnections record {
     # Related content for this activity.
-    Activity31MetadataConnectionsRelated related;
+    Activity31MetadataConnectionsRelated? related;
 };
 
 # Information about this user's subscribed channels.
@@ -498,6 +570,11 @@ public type UserMetadataConnectionsChannels record {
     decimal total;
     # The API URI that resolves to the connection data.
     string uri;
+};
+
+public type PicturesPosterIdBody record {
+    # Whether to make this picture the active picture.
+    boolean active?;
 };
 
 # Information about the groups related to this category.
@@ -528,6 +605,46 @@ public type VideoMetadataConnectionsSeason record {
     string[] options;
     # The API URI that resolves to the connection data.
     string uri;
+};
+
+public type ChannelsChannelIdBody record {
+    # The description of the channel.
+    string description?;
+    # The link to access the channel. You can use a custom name in the URL in place of a numeric channel ID, as in `/channels/{url_custom}`. Submitting `""` for this field removes the link alias.
+    string link?;
+    # The name of the channel.
+    string name?;
+    # The privacy level of the channel.
+    string privacy?;
+};
+
+public type AlbumsAlbumIdBody1 record {
+    # The hexadecimal code for the color of the player buttons.
+    string brand_color?;
+    # The description of the album.
+    string description?;
+    # The custom domain a user has selected for their album.
+    string? domain?;
+    # Whether to hide Vimeo navigation when displaying the album.
+    boolean hide_nav?;
+    # The type of layout for presenting the album.
+    string layout?;
+    # The name of the album.
+    string name?;
+    # The album's password. Required only if **privacy** is `password`.
+    string password?;
+    # The privacy level of the album.
+    string privacy?;
+    # Whether album videos should use the review mode URL.
+    boolean review_mode?;
+    # The default sort order of the album's videos.
+    string sort?;
+    # The color theme of the album.
+    string theme?;
+    # The custom Vimeo URL a user has selected for their album.
+    string? url?;
+    # Whether the user has opted in to use a custom domain for their album.
+    boolean use_custom_domain?;
 };
 
 public type Project record {
@@ -567,6 +684,17 @@ public type AuthError record {
     string error_description;
 };
 
+public type TexttracksTexttrackIdBody record {
+    # Whether the text track is active, meaning that it appears in the player. Only one text track per language, and type, can be active.
+    boolean active?;
+    # The language of the text track. For a full list of valid languages, use the [/languages?filter=texttracks](https://developer.vimeo.com/api/endpoints/videos#GET/languages) endpoint.
+    string language?;
+    # The name of the text track.
+    string name?;
+    # The text track type.
+    string 'type?;
+};
+
 public type ContentRating record {
     # The code that uniquely identifies this content rating:
     # 
@@ -582,6 +710,26 @@ public type ContentRating record {
     string name;
     # The canonical relative URI of the content rating.
     string? uri;
+};
+
+public type VideosVideoIdBody1 record {
+    # A list of values describing the content in this video. You can find the full list in the [`/contentratings`](https://developer.vimeo.com/api/endpoints/videos#GET/contentratings) endpoint.
+    string[] content_rating?;
+    # The new description of the video.
+    string description?;
+    MevideosEmbed embed?;
+    # The Creative Commons license.
+    string license?;
+    # The video's default language. For a full list of valid languages, use the [/languages?filter=texttracks](https://developer.vimeo.com/api/endpoints/videos#GET/languages) endpoint.
+    string locale?;
+    # The new title for the video.
+    string name?;
+    # The password. When you set `privacy.view` to `password`, you must provide the password as an additional parameter.
+    string password?;
+    VideosvideoIdPrivacy privacy?;
+    MevideosRatings ratings?;
+    MevideosReviewPage review_page?;
+    MevideosSpatial spatial?;
 };
 
 public type Group record {
@@ -612,17 +760,17 @@ public type Group record {
 # A list of resource URIs related to the video.
 public type VideoMetadataInteractions record {
     # The Buy interaction for a On Demand video.
-    VideoMetadataInteractionsBuy buy;
+    VideoMetadataInteractionsBuy? buy;
     # When a video is referenced by a channel URI, if the user is a moderator of the channel, include information about removing the video from the channel.
-    VideoMetadataInteractionsChannel 'channel;
+    VideoMetadataInteractionsChannel? 'channel;
     # Information about whether the authenticated user has liked this video.
     VideoMetadataInteractionsLike like;
     # The Rent interaction for an On Demand video.
-    VideoMetadataInteractionsRent rent;
+    VideoMetadataInteractionsRent? rent;
     # Information about where and how to report a video.
     VideoMetadataInteractionsReport report;
     # Subscription information for an On Demand video.
-    VideoMetadataInteractionsSubscribe subscribe?;
+    VideoMetadataInteractionsSubscribe? subscribe?;
     # Information about removing this video from the user's list of watched videos.
     VideoMetadataInteractionsWatched watched;
     # Information about whether this video appears on the authenticated user's Watch Later list.
@@ -657,6 +805,17 @@ public type VideoMetadataInteractionsWatchlater record {
     string uri;
 };
 
+public type ChannelsBody record {
+    # The description of the channel.
+    string description?;
+    # The link to access the channel. You can use a custom name in the URL in place of a numeric channel ID, as in `/channels/{url_custom}`.
+    string link?;
+    # The name of the channel.
+    string name;
+    # The privacy level of the channel.
+    string privacy;
+};
+
 # Information about the likes associated with this page.
 public type OndemandpageMetadataConnectionsMetadataConnectionsLikes record {
     # An array of HTTP methods permitted on this URI.
@@ -677,6 +836,15 @@ public type VideoMetadata record {
     VideoMetadataConnections connections;
     # A list of resource URIs related to the video.
     VideoMetadataInteractions interactions;
+};
+
+public type VideoIdTagsBody record {
+    # The name of the tag to apply. See our documentation on [batch requests](https://developer.vimeo.com/api/common-formats#batch-requests) for more information.
+    string name;
+    # The page number of the results to show.
+    decimal page?;
+    # The number of items to show on each page of results, up to a maximum of 100.
+    decimal per_page?;
 };
 
 # Information about the user's followers.
@@ -709,11 +877,11 @@ public type MeondemandpagesBuy record {
 
 public type PurchaseInteraction record {
     # Information on purchasing this video.
-    PurchaseinteractionBuy buy?;
+    PurchaseinteractionBuy? buy?;
     # Information on renting this video.
     record {} rent?;
     # Information on subscribing to this video.
-    PurchaseinteractionSubscribe subscribe?;
+    PurchaseinteractionSubscribe? subscribe?;
 };
 
 public type OndemandpageMetadataConnectionsMetadataConnections record {
@@ -729,6 +897,38 @@ public type OndemandpageMetadataConnectionsMetadataConnections record {
     OndemandpageMetadataConnectionsMetadataConnectionsSeasons seasons;
     # Information about the videos associated with this page.
     OndemandpageMetadataConnectionsMetadataConnectionsVideos videos;
+};
+
+public type VideosVideoIdBody record {
+    OndemandpagesondemandIdvideosvideoIdBuy buy?;
+    # The position of this video in the On Demand collection.
+    decimal position?;
+    # The video release year.
+    decimal release_year?;
+    OndemandpagesondemandIdvideosvideoIdRent rent?;
+    # The type of video that you are adding to the On Demand page.
+    string 'type;
+};
+
+public type VideoIdCommentsBody record {
+    # The text of the comment.
+    string text;
+};
+
+public type MeBody record {
+    # The user's bio.
+    string bio?;
+    # A list of values describing the content in this video. Find the full list in the [/contentratings](https://developer.vimeo.com/api/endpoints/videos#GET/contentratings) endpoint. You must provide a comma-separated list if you are using a query string or an array if you are using JSON.
+    string[] content_filter?;
+    # The user's custom Vimeo URL slug.
+    string link?;
+    # The user's location.
+    string location?;
+    # The user's display name.
+    string name?;
+    # The default password for all future videos that this user uploads. To use this field, the `videos.privacy.view` field must be `password`.
+    string password?;
+    MeVideos videos?;
 };
 
 # An action indicating that the authenticated user is an admin of the album and may therefore add videos. This data requires a bearer token with the `private` scope.
@@ -825,9 +1025,58 @@ public type ApiApp record {
     string uri;
 };
 
+public type CreditsCreditIdBody record {
+    # The name of the person being credited.
+    string name?;
+    # The role of the person being credited.
+    string role?;
+};
+
 public type MeondemandpagesSubscriptionMonthlyPrice record {
     # The monthly subscription price in USD. *Required if `subscription.active` is true.
     decimal USD?;
+};
+
+public type PresetsPresetIdBody record {
+    # Disable the outro.
+    string outro?;
+};
+
+public type UserIdAlbumsBody record {
+    # The hexadecimal code for the color of the player buttons.
+    string brand_color?;
+    # The description of the album.
+    string description?;
+    # Whether to hide Vimeo navigation when displaying the album.
+    boolean hide_nav?;
+    # The type of layout for presenting the album.
+    string layout?;
+    # The name of the album.
+    string name;
+    # The album's password. Required only if **privacy** is `password`.
+    string password?;
+    # The privacy level of the album.
+    string privacy?;
+    # Whether album videos should use the review mode URL.
+    boolean review_mode?;
+    # The default sort order of the album's videos.
+    string sort?;
+    # The color theme of the album.
+    string theme?;
+};
+
+public type PrivacyUsersBody record {
+    # The array of either the user URIs or the user IDs to permit to view the private channel.
+    string[] users;
+};
+
+public type AuthorizeVimeoOauth1Body record {
+    # The grant type. Must be set to `vimeo_oauth1`.
+    string grant_type;
+    # The OAuth 1 token.
+    string token;
+    # The OAuth 1 token secret.
+    string token_secret;
 };
 
 # Metadata about the channel.
@@ -835,7 +1084,7 @@ public type ChannelMetadata record {
     # A collection of information that is connected to this resource.
     ChannelMetadataConnections connections;
     # A list of resource URIs related to the channel.
-    ChannelMetadataInteractions interactions;
+    ChannelMetadataInteractions? interactions;
 };
 
 # When a channel appears in the context of adding or removing a video from it (`/videos/{video_id}/available_channels`), include information about adding or removing the video. This data requires a bearer token with the `private` scope.
@@ -892,6 +1141,57 @@ public type VideoMetadataInteractionsChannel record {
     string uri;
 };
 
+public type UsersUserIdBody record {
+    # The user's bio.
+    string bio?;
+    # A list of values describing the content in this video. Find the full list in the [/contentratings](https://developer.vimeo.com/api/endpoints/videos#GET/contentratings) endpoint. You must provide a comma-separated list if you are using a query string or an array if you are using JSON.
+    string[] content_filter?;
+    # The user's custom Vimeo URL slug.
+    string link?;
+    # The user's location.
+    string location?;
+    # The user's display name.
+    string name?;
+    # The default password for all future videos that this user uploads. To use this field, the `videos.privacy.view` field must be `password`.
+    string password?;
+    MeVideos videos?;
+};
+
+public type OndemandPagesBody1 record {
+    # An array of accepted currencies.
+    # 
+    # Option descriptions:
+    #  * `AUD` - Australian Dollar
+    #  * `CAD` - Canadian Dollar
+    #  * `CHF` - Swiss Franc
+    #  * `DKK` - Danish Krone
+    #  * `EUR` - Euro
+    #  * `GBP` - British Pound
+    #  * `JPY` - Japanese Yen
+    #  * `KRW` - South Korean Won
+    #  * `NOK` - Norwegian Krone
+    #  * `PLN` - Polish Zloty
+    #  * `SEK` - Swedish Krona
+    #  * `USD` - US Dollar
+    string accepted_currencies?;
+    MeondemandpagesBuy buy?;
+    # One or more ratings, either as a comma-separated list or as a JSON array depending on the request format.
+    string content_rating;
+    # The description of the On Demand page.
+    string description;
+    # The custom domain of the On Demand page.
+    string domain_link?;
+    MeondemandpagesEpisodes episodes?;
+    # The custom string to use in this On Demand page's Vimeo URL.
+    string link?;
+    # The name of the On Demand page.
+    string name;
+    MeondemandpagesRent rent?;
+    MeondemandpagesSubscription subscription?;
+    # The type of On Demand page.
+    string 'type;
+};
+
 public type MeondemandpagesEpisodesBuy record {
     # Whether episodes can be bought.
     boolean active?;
@@ -926,6 +1226,11 @@ public type PresetsSettingsOutroLink record {
     string name?;
     # The URL of the outro link.
     string url?;
+};
+
+public type VideoIdCategoriesBody record {
+    # The array of the names of the categories that you're suggesting.
+    string[] category;
 };
 
 # Information about this video's text tracks.
@@ -1070,15 +1375,20 @@ public type Video record {
     # An array of all tags assigned to this video.
     Tag[] tags;
     # The transcode information for a video upload.
-    VideoTranscode transcode;
+    VideoTranscode? transcode;
     # The upload information for this video.
-    VideoUpload upload;
+    VideoUpload? upload;
     # The video's canonical relative URI.
     string uri;
     # The video owner.
     record {*User;} user;
     # The video's width in pixels.
     decimal width;
+};
+
+public type PicturesPictureIdBody record {
+    # Whether this thumbnail is the default.
+    boolean active?;
 };
 
 public type Domain record {
@@ -1188,7 +1498,7 @@ public type OnDemandPage record {
     # The creator-designated SKU for this On Demand page.
     string? sku?;
     # Information about subscribing to this On Demand page, if enabled.
-    OndemandpageSubscription subscription;
+    OndemandpageSubscription? subscription;
     # The graphical theme for this On Demand page.
     string theme;
     # The thumbnail image for the On Demand page on Vimeo.
@@ -1245,6 +1555,11 @@ public type OndemandpagesondemandIdvideosvideoIdRentPrice record {
     decimal SEK?;
     # The rental price of this video in USD. *Required if `rent.active` is true.
     decimal USD?;
+};
+
+public type ChannelIdTagsBody record {
+    # An array of tags to assign.
+    string[] tag;
 };
 
 # A collection of information relating to the embeddable player's title bar.
@@ -1309,6 +1624,16 @@ public type VideoversionsUpload record {
     string status;
     # The link for sending video file data.
     string upload_link?;
+};
+
+public type ProjectsProjectIdBody1 record {
+    # The name of the project.
+    string name;
+};
+
+public type VideoIdCommentsBody1 record {
+    # The text of the comment.
+    string text;
 };
 
 # Related content for this activity.
@@ -1392,6 +1717,11 @@ public type MeondemandpagesRentPrice record {
     decimal USD?;
 };
 
+public type ChannelIdModeratorsBody record {
+    # The URI of a user to add as a moderator.
+    string user_uri;
+};
+
 # The contents of the presets group.
 public type PresetsSettings record {
     PresetsSettingsButtons buttons;
@@ -1443,6 +1773,33 @@ public type UserUploadQuotaSpace record {
     decimal used;
 };
 
+public type MeFollowingBody record {
+    # An array of user URIs for the list of users to follow.
+    string[] users;
+};
+
+public type UserIdFollowingBody record {
+    # An array of user URIs for the list of users to follow.
+    string[] users;
+};
+
+public type VideoIdVersionsBody record {
+    # The name of the version
+    string file_name;
+    VideosvideoIdversionsUpload upload;
+};
+
+public type VideoIdTexttracksBody1 record {
+    # Active text tracks appear in the player and are visible to other users. Only one text track per language can be active.
+    boolean active?;
+    # The language of the text track. For a complete list of valid languages, use the [/languages?filter=texttracks](https://developer.vimeo.com/api/endpoints/videos#GET/languages) endpoint.
+    string language;
+    # The name of the text track.
+    string name;
+    # The type of the text track.
+    string 'type;
+};
+
 public type MeondemandpagesEpisodes record {
     MeondemandpagesEpisodesBuy buy?;
     MeondemandpagesEpisodesRent rent?;
@@ -1458,9 +1815,44 @@ public type UserMetadataConnectionsModeratedChannels record {
     string uri;
 };
 
+public type OauthAccessTokenBody record {
+    # The authorization code received from the authorization server.
+    string code;
+    # The grant type. Must be set to `authorization_code`.
+    string grant_type;
+    # The redirect URI. Must match the URI from `/oauth/authorize`.
+    string redirect_uri;
+};
+
+public type PresetsPresetIdBody1 record {
+    # Disable the outro.
+    string outro?;
+};
+
 public type MevideosRatings record {
     MevideosRatingsMpaa mpaa?;
     MevideosRatingsTv tv?;
+};
+
+public type MeVideosBody record {
+    # A list of values describing the content in this video. Find the full list in the [/contentratings](https://developer.vimeo.com/api/endpoints/videos#GET/contentratings) endpoint.
+    string[] content_rating?;
+    # The description of the video.
+    string description?;
+    MevideosEmbed embed?;
+    # The Creative Commons license.
+    string license?;
+    # The video's default language. For a full list of valid languages, use the [/languages?filter=texttracks](https://developer.vimeo.com/api/endpoints/videos#GET/languages) endpoint.
+    string locale?;
+    # The title of the video.
+    string name?;
+    # The password. When you set `privacy.view` to `password`, you must provide the password as an additional parameter.
+    string password?;
+    MevideosPrivacy privacy?;
+    MevideosRatings ratings?;
+    MevideosReviewPage review_page?;
+    MevideosSpatial spatial?;
+    MevideosUpload upload;
 };
 
 # The upload information for this video.
@@ -1495,7 +1887,7 @@ public type OndemandseasonMetadataConnections record {
 
 public type OnDemandVideo record {
     # Information about purchasing this video.
-    OndemandvideoBuy buy;
+    OndemandvideoBuy? buy;
     # Description of the On Demand video.
     string description?;
     # The duration of the On Demand video.
@@ -1523,7 +1915,7 @@ public type OnDemandVideo record {
     # The year that this On Demand video was released.
     decimal? release_year;
     # Information about renting this video.
-    OndemandvideoRent rent;
+    OndemandvideoRent? rent;
     # The type of the On Demand video:
     # 
     # Option descriptions:
@@ -1596,6 +1988,11 @@ public type UploadAttempt record {
     record {*User;} user;
 };
 
+public type OndemandIdRegionsBody record {
+    # An array of country codes.
+    string[] countries;
+};
+
 # The primary and secondary colors used for rendering this On Demand page.
 public type OndemandpageColors record {
     # The hexadecimal color code for the page's primary color.
@@ -1604,15 +2001,33 @@ public type OndemandpageColors record {
     string secondary;
 };
 
-public type Body56 record {
-    # The email address of the credited person.
-    string email;
-    # The name of the credited person.
-    string name;
-    # The role of the credited person.
-    string role;
-    # The URI of the Vimeo user who should be given credit in this video.
-    string user_uri;
+public type AlbumsAlbumIdBody record {
+    # The hexadecimal code for the color of the player buttons.
+    string brand_color?;
+    # The description of the album.
+    string description?;
+    # The custom domain a user has selected for their album.
+    string? domain?;
+    # Whether to hide Vimeo navigation when displaying the album.
+    boolean hide_nav?;
+    # The type of layout for presenting the album.
+    string layout?;
+    # The name of the album.
+    string name?;
+    # The album's password. Required only if **privacy** is `password`.
+    string password?;
+    # The privacy level of the album.
+    string privacy?;
+    # Whether album videos should use the review mode URL.
+    boolean review_mode?;
+    # The default sort order of the album's videos.
+    string sort?;
+    # The color theme of the album.
+    string theme?;
+    # The custom Vimeo URL a user has selected for their album.
+    string? url?;
+    # Whether the user has opted in to use a custom domain for their album.
+    boolean use_custom_domain?;
 };
 
 # The Buy interaction for a On Demand video.
@@ -1647,11 +2062,6 @@ public type VideoMetadataInteractionsBuy record {
     string 'stream;
     # The product URI to purchase the On Demand video.
     string? uri;
-};
-
-public type Body55 record {
-    # The reply to the comment.
-    string text;
 };
 
 # Information about the pictures associated with this page.
@@ -1691,32 +2101,10 @@ public type UserMetadata record {
     UserMetadataInteractions interactions;
 };
 
-public type Body54 record {
-    # The next text of the comment.
-    string text;
-};
-
-public type Body53 record {
-    # The text of the comment.
-    string text;
-};
-
 # A collection of information connected to this resource.
 public type OndemandgenreMetadataConnections record {
     # Information about the On Demand pages related to this group.
     OndemandgenreMetadataConnectionsPages pages;
-};
-
-public type Body59 record {
-    # Whether this thumbnail is the default.
-    boolean active?;
-};
-
-public type Body58 record {
-    # Whether the image created by the `time` field should be the default thumbnail for the video.
-    boolean active?;
-    # Creates an image of the video from the given time offset.
-    decimal time?;
 };
 
 # Information about removing this video from the user's list of watched videos.
@@ -1742,18 +2130,11 @@ public type MevideosUpload record {
     string size?;
 };
 
-public type Body57 record {
-    # The name of the person being credited.
-    string name?;
-    # The role of the person being credited.
-    string role?;
-};
-
 public type PresetsSettingsOutro record {
     # A comma-separated list of video URIs. Present only if the type is `uploaded_clips`.
     string? clips?;
     # The outro link settings. Present only if the type is `link`.
-    PresetsSettingsOutroLink link?;
+    PresetsSettingsOutroLink? link?;
     # The outro text. Present only if the type is `text`.
     string? text?;
     # The preset outro type:
@@ -1780,34 +2161,6 @@ public type Presets record {
     record {*User;} user;
 };
 
-public type Body63 record {
-    # The name of the version
-    string file_name;
-    VideosvideoIdversionsUpload upload;
-};
-
-public type Body62 record {
-    # Whether the text track is active, meaning that it appears in the player. Only one text track per language, and type, can be active.
-    boolean active?;
-    # The language of the text track. For a full list of valid languages, use the [/languages?filter=texttracks](https://developer.vimeo.com/api/endpoints/videos#GET/languages) endpoint.
-    string language?;
-    # The name of the text track.
-    string name?;
-    # The text track type.
-    string 'type?;
-};
-
-public type Body61 record {
-    # Active text tracks appear in the player and are visible to other users. Only one text track per language can be active.
-    boolean active?;
-    # The language of the text track. For a complete list of valid languages, use the [/languages?filter=texttracks](https://developer.vimeo.com/api/endpoints/videos#GET/languages) endpoint.
-    string language;
-    # The name of the text track.
-    string name;
-    # The type of the text track.
-    string 'type;
-};
-
 # Information about this comment's replies.
 public type CommentMetadataConnectionsReplies record {
     # An array of HTTP methods permitted on this URI.
@@ -1822,15 +2175,6 @@ public type CommentMetadataConnectionsReplies record {
 public type ProjectMetadata record {
     # A list of resource URIs related to the project.
     ProjectMetadataConnections connections;
-};
-
-public type Body60 record {
-    # The name of the tag to apply. See our documentation on [batch requests](https://developer.vimeo.com/api/common-formats#batch-requests) for more information.
-    string name;
-    # The page number of the results to show.
-    decimal page?;
-    # The number of items to show on each page of results, up to a maximum of 100.
-    decimal per_page?;
 };
 
 public type OndemandpagesondemandIdvideosvideoIdBuyPrice record {
@@ -1927,57 +2271,17 @@ public type Activity31 record {
     record {*User;} user?;
 };
 
+public type MeProjectsBody record {
+    # The name of the project.
+    string name;
+};
+
 # A collection of information that is connected to this resource.
 public type GroupMetadataConnections record {
     # Information about the members or moderators of this group.
     GroupMetadataConnectionsUsers users;
     # Information about the videos contained within this group.
     GroupMetadataConnectionsVideos videos;
-};
-
-public type Body45 record {
-    # An array of accepted currencies.
-    # 
-    # Option descriptions:
-    #  * `AUD` - Australian Dollar
-    #  * `CAD` - Canadian Dollar
-    #  * `CHF` - Swiss Franc
-    #  * `DKK` - Danish Krone
-    #  * `EUR` - Euro
-    #  * `GBP` - British Pound
-    #  * `JPY` - Japanese Yen
-    #  * `KRW` - South Korean Won
-    #  * `NOK` - Norwegian Krone
-    #  * `PLN` - Polish Zloty
-    #  * `SEK` - Swedish Krona
-    #  * `USD` - US Dollar
-    string accepted_currencies?;
-    MeondemandpagesBuy buy?;
-    # One or more ratings, either as a comma-separated list or as a JSON array depending on the request format.
-    string content_rating;
-    # The description of the On Demand page.
-    string description;
-    # The custom domain of the On Demand page.
-    string domain_link?;
-    MeondemandpagesEpisodes episodes?;
-    # The custom string to use in this On Demand page's Vimeo URL.
-    string link?;
-    # The name of the On Demand page.
-    string name;
-    MeondemandpagesRent rent?;
-    MeondemandpagesSubscription subscription?;
-    # The type of On Demand page.
-    string 'type;
-};
-
-public type Body44 record {
-    # An array of user URIs for the list of users to follow.
-    string[] users;
-};
-
-public type Body43 record {
-    # The video frame time in seconds to use as the album thumbnail.
-    decimal time_code?;
 };
 
 public type CreativeCommons record {
@@ -1998,11 +2302,6 @@ public type CreativeCommons record {
     string? uri;
 };
 
-public type Body42 record {
-    # A comma-separated list of video URIs.
-    string videos;
-};
-
 # Information about this user's followed categories.
 public type UserMetadataConnectionsCategories record {
     # An array of HTTP methods permitted on this URI.
@@ -2013,29 +2312,14 @@ public type UserMetadataConnectionsCategories record {
     string uri;
 };
 
-public type Body49 record {
-    # The name of the project.
-    string name;
-};
-
-public type Body48 record {
-    # The name of the project.
-    string name;
-};
-
-public type Body47 record {
-    # Disable the outro.
-    string outro?;
-};
-
 public type MeondemandpagesEpisodesBuyPrice record {
     # The purchase price per episode. *Required if `episodes.buy.active` is true.
     decimal USD?;
 };
 
-public type Body46 record {
-    # Whether the picture is the user's active portrait.
-    boolean active?;
+public type CommentsCommentIdBody record {
+    # The next text of the comment.
+    string text;
 };
 
 # A collection of information about the logo in the corner of the embeddable player.
@@ -2049,52 +2333,6 @@ public type EmbedsettingsLogos record {
 public type MevideosReviewPage record {
     # Enable or disable video review.
     boolean active?;
-};
-
-public type Body52 record {
-    # The array of the names of the categories that you're suggesting.
-    string[] category;
-};
-
-public type Body51 record {
-    # A list of values describing the content in this video. You can find the full list in the [`/contentratings`](https://developer.vimeo.com/api/endpoints/videos#GET/contentratings) endpoint.
-    string[] content_rating?;
-    # The new description of the video.
-    string description?;
-    MevideosEmbed embed?;
-    # The Creative Commons license.
-    string license?;
-    # The video's default language. For a full list of valid languages, use the [/languages?filter=texttracks](https://developer.vimeo.com/api/endpoints/videos#GET/languages) endpoint.
-    string locale?;
-    # The new title for the video.
-    string name?;
-    # The password. When you set `privacy.view` to `password`, you must provide the password as an additional parameter.
-    string password?;
-    VideosvideoIdPrivacy privacy?;
-    MevideosRatings ratings?;
-    MevideosReviewPage review_page?;
-    MevideosSpatial spatial?;
-};
-
-public type Body50 record {
-    # A list of values describing the content in this video. Find the full list in the [/contentratings](https://developer.vimeo.com/api/endpoints/videos#GET/contentratings) endpoint.
-    string[] content_rating?;
-    # The description of the video.
-    string description?;
-    MevideosEmbed embed?;
-    # The Creative Commons license.
-    string license?;
-    # The video's default language. For a full list of valid languages, use the [/languages?filter=texttracks](https://developer.vimeo.com/api/endpoints/videos#GET/languages) endpoint.
-    string locale?;
-    # The title of the video.
-    string name?;
-    # The password. When you set `privacy.view` to `password`, you must provide the password as an additional parameter.
-    string password?;
-    MevideosPrivacy privacy?;
-    MevideosRatings ratings?;
-    MevideosReviewPage review_page?;
-    MevideosSpatial spatial?;
-    MevideosUpload upload;
 };
 
 # 360 spatial data.
@@ -2159,6 +2397,11 @@ public type UserPreferences record {
     UserPreferencesVideos videos?;
 };
 
+public type ChannelIdVideosBody record {
+    # The URI of a video to add.
+    string video_uri;
+};
+
 public type MeondemandpagesEpisodesRent record {
     # Whether episodes can be rented
     boolean active?;
@@ -2167,33 +2410,9 @@ public type MeondemandpagesEpisodesRent record {
     MeondemandpagesEpisodesRentPrice price?;
 };
 
-public type Body39 record {
-    # The hexadecimal code for the color of the player buttons.
-    string brand_color?;
-    # The description of the album.
-    string description?;
-    # The custom domain a user has selected for their album.
-    string? domain?;
-    # Whether to hide Vimeo navigation when displaying the album.
-    boolean hide_nav?;
-    # The type of layout for presenting the album.
-    string layout?;
-    # The name of the album.
-    string name?;
-    # The album's password. Required only if **privacy** is `password`.
-    string password?;
-    # The privacy level of the album.
-    string privacy?;
-    # Whether album videos should use the review mode URL.
-    boolean review_mode?;
-    # The default sort order of the album's videos.
-    string sort?;
-    # The color theme of the album.
-    string theme?;
-    # The custom Vimeo URL a user has selected for their album.
-    string? url?;
-    # Whether the user has opted in to use a custom domain for their album.
-    boolean use_custom_domain?;
+public type AlbumIdVideosBody1 record {
+    # A comma-separated list of video URIs.
+    string videos;
 };
 
 public type OndemandvideoMetadataInteractions record {
@@ -2218,81 +2437,9 @@ public type OndemandpagesondemandIdPublish record {
     boolean active?;
 };
 
-public type Body34 record {
-    # An array of country codes.
-    string[] countries;
-};
-
-public type Body33 record {
-    # The promotion access type, which is a purchase option that isn't available on the container. VIP promotions always make the content free of charge. If you use this type, you must further define the promotion with the `download` or `stream_period` fields.
-    # 
-    # Option descriptions:
-    #  * `default` - Promotions grant discount on the existing purchase options for an On Demand Container.
-    #  * `vip` - Promotions can be used to grant free access to VOD content before it is released, or to offer a purchase option that isn't available on the container. "vip" promotions will always make the content free, and must be further defined with the `download` or `stream_period` fields.
-    string access_type?;
-    # The promotion code. This field is ignored for batch promotions.
-    string code?;
-    # The type of discount offered by the promo code. When `access_type` is `vip`, the value of this field must be `free`.
-    # 
-    # Option descriptions:
-    #  * `free` - Reduces the price to zero.
-    #  * `percent` - Reduces the price by an amount defined in the "percent_off" field.
-    string discount_type?;
-    # Whether the promotion grants download access to VOD content. This is necessary only when not previously defined in the On Demand container or when `access_type` is `vip` or `product_type` is `buy`.
-    boolean download;
-    # The end of the promotion period. If you don't specify a value, the promotion will never expire.
-    string end_time?;
-    # The description of a batch promotion. This field is ignored for single promotions.
-    string label?;
-    # The percentage of the discount by using this promo code. This field is applicable only when `discount_type` is `percent`.
-    decimal percent_off?;
-    # The type of transaction to which the promotion applies. When `access_type` is `default`, the default value is `any`, but the default value is `rent` when `access_type` is `vip`. Also, when `access_type` is `vip`, the only valid product types are `buy` and `rent`.
-    string product_type?;
-    # The start of the promotion period. If you don't specify a value, the start time defaults to the time that the promotion was created.
-    string start_time?;
-    # The amount of time that a user has access to the VOD content upon redeeming a promo code. This field is necessary only when not defined in the On Demand container or when creating promotions when `access_type` is `vip` or `product_type` is `rent`.
-    string stream_period;
-    # The number of promotions to generate when `type` is `batch`, or the number of uses of the promotion when `type` is `single`.
-    decimal total;
-    # The type of promotion. When `access_type` is `vip`, the value for this field must be `batch`.
-    # 
-    # Option descriptions:
-    #  * `batch` - Generates many random promo codes with one use each.
-    #  * `single` - Generates one promo code that can be used many times.
-    string 'type;
-};
-
-public type Body32 record {
-    # Whether to make this picture the active picture.
-    boolean active?;
-};
-
-public type Body31 record {
+public type BackgroundsBackgroundIdBody record {
     # Whether to make this background the active background.
     boolean active?;
-};
-
-public type Body38 record {
-    # The hexadecimal code for the color of the player buttons.
-    string brand_color?;
-    # The description of the album.
-    string description?;
-    # Whether to hide Vimeo navigation when displaying the album.
-    boolean hide_nav?;
-    # The type of layout for presenting the album.
-    string layout?;
-    # The name of the album.
-    string name;
-    # The album's password. Required only if **privacy** is `password`.
-    string password?;
-    # The privacy level of the album.
-    string privacy?;
-    # Whether album videos should use the review mode URL.
-    boolean review_mode?;
-    # The default sort order of the album's videos.
-    string sort?;
-    # The color theme of the album.
-    string theme?;
 };
 
 # Information about the videos that this user has watched.
@@ -2305,22 +2452,6 @@ public type UserMetadataConnectionsWatchedVideos record {
     string uri;
 };
 
-public type Body37 record {
-    # The user's bio.
-    string bio?;
-    # A list of values describing the content in this video. Find the full list in the [/contentratings](https://developer.vimeo.com/api/endpoints/videos#GET/contentratings) endpoint. You must provide a comma-separated list if you are using a query string or an array if you are using JSON.
-    string[] content_filter?;
-    # The user's custom Vimeo URL slug.
-    string link?;
-    # The user's location.
-    string location?;
-    # The user's display name.
-    string name?;
-    # The default password for all future videos that this user uploads. To use this field, the `videos.privacy.view` field must be `password`.
-    string password?;
-    MeVideos videos?;
-};
-
 public type MevideosRatingsTv record {
     # The reason for the video's TV rating.
     # 
@@ -2331,22 +2462,6 @@ public type MevideosRatingsTv record {
     #  * `ss` - Sexual situations
     #  * `v` - Violence
     string reason?;
-};
-
-public type Body36 record {
-    OndemandpagesondemandIdvideosvideoIdBuy buy?;
-    # The position of this video in the On Demand collection.
-    decimal position?;
-    # The video release year.
-    decimal release_year?;
-    OndemandpagesondemandIdvideosvideoIdRent rent?;
-    # The type of video that you are adding to the On Demand page.
-    string 'type;
-};
-
-public type Body35 record {
-    # An array of country codes.
-    string[] countries?;
 };
 
 # Information about the comments on this video.
@@ -2369,22 +2484,12 @@ public type OndemandpageMetadataConnectionsMetadataConnectionsSeasons record {
     string uri;
 };
 
-public type Body41 record {
-    # Whether to make this the active album logo.
-    boolean active?;
-};
-
 # Metadata about the category.
 public type CategoryMetadata record {
     # A collection of information that is connected to this resource.
     CategoryMetadataConnections connections;
     # The permissible actions related to the category.
     CategoryMetadataInteractions interactions;
-};
-
-public type Body40 record {
-    # Whether to make this the active album thumbnail.
-    boolean active?;
 };
 
 public type VideosvideoIdPrivacy record {
@@ -2424,46 +2529,10 @@ public type AlbumMetadataInteractions record {
     AlbumMetadataInteractionsAddVideos add_videos;
 };
 
-public type Body8 record {
-    # The URI of a video to add.
-    string video_uri;
-};
-
-public type Body9 record {
-    # The URI of a video to remove.
-    string video_uri;
-};
-
-public type Body6 record {
-    # The array of either the user URIs or the user IDs to permit to view the private channel.
-    string[] users;
-};
-
-public type Body29 record {
-    # The grant type. Must be set to `vimeo_oauth1`.
-    string grant_type;
-    # The OAuth 1 token.
-    string token;
-    # The OAuth 1 token secret.
-    string token_secret;
-};
-
 # A list of resource URIs related to the project.
 public type ProjectMetadataConnections record {
     # A standard connection object indicating how to get all the videos in this project.
     ProjectMetadataConnectionsVideos videos;
-};
-
-public type Body7 record {
-    # An array of tags to assign.
-    string[] tag;
-};
-
-public type Body28 record {
-    # The grant type. Must be set to `client_credentials`.
-    string grant_type;
-    # A space-separated list of the authentication [scopes](https://developer.vimeo.com/api/authentication#supported-scopes) that you want to access. The default is `public`.
-    string scope;
 };
 
 public type CategorySubcategories record {
@@ -2473,11 +2542,6 @@ public type CategorySubcategories record {
     string name;
     # The unique identifier to access the subcategory resource.
     string uri;
-};
-
-public type Body4 record {
-    # The URI of a user to remove as a moderator.
-    string user_uri;
 };
 
 # The permissible actions related to the category.
@@ -2502,14 +2566,43 @@ public type UserUploadQuota record {
     UserUploadQuotaSpace space;
 };
 
-public type Body5 record {
-    # The URI of the user to add as a moderator.
-    string user_uri;
-};
-
-public type Body2 record {
-    # The array of category URIs to add.
-    string[] channels;
+public type OndemandIdPromotionsBody record {
+    # The promotion access type, which is a purchase option that isn't available on the container. VIP promotions always make the content free of charge. If you use this type, you must further define the promotion with the `download` or `stream_period` fields.
+    # 
+    # Option descriptions:
+    #  * `default` - Promotions grant discount on the existing purchase options for an On Demand Container.
+    #  * `vip` - Promotions can be used to grant free access to VOD content before it is released, or to offer a purchase option that isn't available on the container. "vip" promotions will always make the content free, and must be further defined with the `download` or `stream_period` fields.
+    string access_type?;
+    # The promotion code. This field is ignored for batch promotions.
+    string code?;
+    # The type of discount offered by the promo code. When `access_type` is `vip`, the value of this field must be `free`.
+    # 
+    # Option descriptions:
+    #  * `free` - Reduces the price to zero.
+    #  * `percent` - Reduces the price by an amount defined in the "percent_off" field.
+    string discount_type?;
+    # Whether the promotion grants download access to VOD content. This is necessary only when not previously defined in the On Demand container or when `access_type` is `vip` or `product_type` is `buy`.
+    boolean download;
+    # The end of the promotion period. If you don't specify a value, the promotion will never expire.
+    string end_time?;
+    # The description of a batch promotion. This field is ignored for single promotions.
+    string label?;
+    # The percentage of the discount by using this promo code. This field is applicable only when `discount_type` is `percent`.
+    decimal percent_off?;
+    # The type of transaction to which the promotion applies. When `access_type` is `default`, the default value is `any`, but the default value is `rent` when `access_type` is `vip`. Also, when `access_type` is `vip`, the only valid product types are `buy` and `rent`.
+    string product_type?;
+    # The start of the promotion period. If you don't specify a value, the start time defaults to the time that the promotion was created.
+    string start_time?;
+    # The amount of time that a user has access to the VOD content upon redeeming a promo code. This field is necessary only when not defined in the On Demand container or when creating promotions when `access_type` is `vip` or `product_type` is `rent`.
+    string stream_period;
+    # The number of promotions to generate when `type` is `batch`, or the number of uses of the promotion when `type` is `single`.
+    decimal total;
+    # The type of promotion. When `access_type` is `vip`, the value for this field must be `batch`.
+    # 
+    # Option descriptions:
+    #  * `batch` - Generates many random promo codes with one use each.
+    #  * `single` - Generates one promo code that can be used many times.
+    string 'type;
 };
 
 public type Portfolio record {
@@ -2537,11 +2630,6 @@ public type Portfolio record {
     string uri;
 };
 
-public type Body3 record {
-    # The URI of a user to add as a moderator.
-    string user_uri;
-};
-
 # Information about the appearances of this user in other videos.
 public type UserMetadataConnectionsAppearances record {
     # An array of HTTP methods permitted on this URI.
@@ -2552,18 +2640,8 @@ public type UserMetadataConnectionsAppearances record {
     string uri;
 };
 
-public type Body23 record {
-    # Disable the outro.
-    string outro?;
-};
-
 public type UserPreferencesVideos record {
     UserPreferencesVideosPrivacy privacy?;
-};
-
-public type Body22 record {
-    # Whether the picture is the user's active portrait.
-    boolean active?;
 };
 
 # Information about the users following or moderating this channel.
@@ -2592,46 +2670,6 @@ public type VideoContext record {
     string resource_type;
 };
 
-public type Body21 record {
-    # An array of accepted currencies.
-    # 
-    # Option descriptions:
-    #  * `AUD` - Australian Dollar
-    #  * `CAD` - Canadian Dollar
-    #  * `CHF` - Swiss Franc
-    #  * `DKK` - Danish Krone
-    #  * `EUR` - Euro
-    #  * `GBP` - British Pound
-    #  * `JPY` - Japanese Yen
-    #  * `KRW` - South Korean Won
-    #  * `NOK` - Norwegian Krone
-    #  * `PLN` - Polish Zloty
-    #  * `SEK` - Swedish Krona
-    #  * `USD` - US Dollar
-    string accepted_currencies?;
-    MeondemandpagesBuy buy?;
-    # One or more ratings, either as a comma-separated list or as a JSON array depending on the request format.
-    string content_rating;
-    # The description of the On Demand page.
-    string description;
-    # The custom domain of the On Demand page.
-    string domain_link?;
-    MeondemandpagesEpisodes episodes?;
-    # The custom string to use in this On Demand page's Vimeo URL.
-    string link?;
-    # The name of the On Demand page.
-    string name;
-    MeondemandpagesRent rent?;
-    MeondemandpagesSubscription subscription?;
-    # The type of On Demand page.
-    string 'type;
-};
-
-public type Body20 record {
-    # An array of user URIs for the list of users to follow.
-    string[] users;
-};
-
 # Information about the codes associated with this promotion.
 public type OndemandpromotionMetadataConnectionsCodes record {
     # An array of HTTP methods permitted on this URI.
@@ -2655,36 +2693,6 @@ public type PresetsSettingsButtons record {
     boolean vote;
     # Whether the preset includes Watch Later button settings.
     boolean watchlater;
-};
-
-public type Body27 record {
-    # The authorization code received from the authorization server.
-    string code;
-    # The grant type. Must be set to `authorization_code`.
-    string grant_type;
-    # The redirect URI. Must match the URI from `/oauth/authorize`.
-    string redirect_uri;
-};
-
-public type Body26 record {
-    # A list of values describing the content in this video. Find the full list in the [/contentratings](https://developer.vimeo.com/api/endpoints/videos#GET/contentratings) endpoint.
-    string[] content_rating?;
-    # The description of the video.
-    string description?;
-    MevideosEmbed embed?;
-    # The Creative Commons license.
-    string license?;
-    # The video's default language. For a full list of valid languages, use the [/languages?filter=texttracks](https://developer.vimeo.com/api/endpoints/videos#GET/languages) endpoint.
-    string locale?;
-    # The title of the video.
-    string name?;
-    # The password. When you set `privacy.view` to `password`, you must provide the password as an additional parameter.
-    string password?;
-    MevideosPrivacy privacy?;
-    MevideosRatings ratings?;
-    MevideosReviewPage review_page?;
-    MevideosSpatial spatial?;
-    MevideosUpload upload;
 };
 
 # The privacy settings of the album.
@@ -2741,14 +2749,27 @@ public type OnDemandPromotionCode record {
     decimal uses;
 };
 
-public type Body25 record {
-    # The name of the project.
+public type MeAlbumsBody record {
+    # The hexadecimal code for the color of the player buttons.
+    string brand_color?;
+    # The description of the album.
+    string description?;
+    # Whether to hide Vimeo navigation when displaying the album.
+    boolean hide_nav?;
+    # The type of layout for presenting the album.
+    string layout?;
+    # The name of the album.
     string name;
-};
-
-public type Body24 record {
-    # The name of the project.
-    string name;
+    # The album's password. Required only if **privacy** is `password`.
+    string password?;
+    # The privacy level of the album.
+    string privacy?;
+    # Whether album videos should use the review mode URL.
+    boolean review_mode?;
+    # The default sort order of the album's videos.
+    string sort?;
+    # The color theme of the album.
+    string theme?;
 };
 
 public type Play record {
@@ -2784,7 +2805,7 @@ public type VideoVersions record {
     # The Play representation.
     record {*Play;} play;
     # The upload information for this version.
-    VideoversionsUpload upload;
+    VideoversionsUpload? upload;
     # The time in ISO 8601 format when the video version was uploaded.
     string? upload_date;
     # The version's canonical relative URI.
@@ -2793,13 +2814,9 @@ public type VideoVersions record {
     record {*User;} user;
 };
 
-public type Body30 record {
-    # The custom string to use in this On Demand page's Vimeo URL.
-    string link?;
-    OndemandpagesondemandIdPreorder preorder?;
-    OndemandpagesondemandIdPublish publish?;
-    # Whether to publish the On Demand page automatically after all videos are finished transcoding.
-    boolean publish_when_ready?;
+public type ChannelIdCategoriesBody record {
+    # The array of category URIs to add.
+    string[] channels;
 };
 
 # An action indicating that the authenticated user is an admin of the album and may therefore add custom logos. This data requires a bearer token with the `private` scope.
@@ -2828,17 +2845,6 @@ public type PresetsMetadataConnections record {
 
 public type MeVideos record {
     MeVideosPrivacy privacy?;
-};
-
-public type Body1 record {
-    # The description of the channel.
-    string description?;
-    # The link to access the channel. You can use a custom name in the URL in place of a numeric channel ID, as in `/channels/{url_custom}`. Submitting `""` for this field removes the link alias.
-    string link?;
-    # The name of the channel.
-    string name?;
-    # The privacy level of the channel.
-    string privacy?;
 };
 
 public type Tag record {
@@ -2898,45 +2904,6 @@ public type OndemandpageEpisodes record {
     OndemandpageEpisodesRent rent;
 };
 
-public type Body19 record {
-    # The video frame time in seconds to use as the album thumbnail.
-    decimal time_code?;
-};
-
-public type Body18 record {
-    # A comma-separated list of video URIs.
-    string videos;
-};
-
-public type Body17 record {
-    # The hexadecimal code for the color of the player buttons.
-    string brand_color?;
-    # The description of the album.
-    string description?;
-    # The custom domain a user has selected for their album.
-    string? domain?;
-    # Whether to hide Vimeo navigation when displaying the album.
-    boolean hide_nav?;
-    # The type of layout for presenting the album.
-    string layout?;
-    # The name of the album.
-    string name?;
-    # The album's password. Required only if **privacy** is `password`.
-    string password?;
-    # The privacy level of the album.
-    string privacy?;
-    # Whether album videos should use the review mode URL.
-    boolean review_mode?;
-    # The default sort order of the album's videos.
-    string sort?;
-    # The color theme of the album.
-    string theme?;
-    # The custom Vimeo URL a user has selected for their album.
-    string? url?;
-    # Whether the user has opted in to use a custom domain for their album.
-    boolean use_custom_domain?;
-};
-
 # Information about the users related to this category.
 public type CategoryMetadataConnectionsUsers record {
     # An array of HTTP methods permitted on this URI.
@@ -2947,11 +2914,21 @@ public type CategoryMetadataConnectionsUsers record {
     string uri;
 };
 
-public type Body12 record {
-    # Whether the image created by the `time` field should be the default thumbnail for the video.
-    boolean active?;
-    # Creates an image of the video from the given time offset.
-    decimal time?;
+public type ProjectsProjectIdBody record {
+    # The name of the project.
+    string name;
+};
+
+public type AuthorizeClientBody record {
+    # The grant type. Must be set to `client_credentials`.
+    string grant_type;
+    # A space-separated list of the authentication [scopes](https://developer.vimeo.com/api/authentication#supported-scopes) that you want to access. The default is `public`.
+    string scope;
+};
+
+public type VideoIdSetAlbumThumbnailBody record {
+    # The video frame time in seconds to use as the album thumbnail.
+    decimal time_code?;
 };
 
 # Information about the users who have liked this video.
@@ -3029,22 +3006,6 @@ public type Album record {
     boolean web_custom_logo;
 };
 
-public type Body11 record {
-    # The email address of the credited person.
-    string email;
-    # The name of the credited person.
-    string name;
-    # The role of the credited person.
-    string role;
-    # The URI of the Vimeo user who should be given credit in this video.
-    string user_uri;
-};
-
-public type Body10 record {
-    # The text of the comment.
-    string text;
-};
-
 public type MevideosEmbedTitle record {
     # Show or hide the video title, or enable the user to determine whether the video title appears.
     string name?;
@@ -3062,45 +3023,6 @@ public type GroupMetadata record {
     GroupMetadataInteractions interactions;
 };
 
-public type Body16 record {
-    # The hexadecimal code for the color of the player buttons.
-    string brand_color?;
-    # The description of the album.
-    string description?;
-    # Whether to hide Vimeo navigation when displaying the album.
-    boolean hide_nav?;
-    # The type of layout for presenting the album.
-    string layout?;
-    # The name of the album.
-    string name;
-    # The album's password. Required only if **privacy** is `password`.
-    string password?;
-    # The privacy level of the album.
-    string privacy?;
-    # Whether album videos should use the review mode URL.
-    boolean review_mode?;
-    # The default sort order of the album's videos.
-    string sort?;
-    # The color theme of the album.
-    string theme?;
-};
-
-public type Body15 record {
-    # The user's bio.
-    string bio?;
-    # A list of values describing the content in this video. Find the full list in the [/contentratings](https://developer.vimeo.com/api/endpoints/videos#GET/contentratings) endpoint. You must provide a comma-separated list if you are using a query string or an array if you are using JSON.
-    string[] content_filter?;
-    # The user's custom Vimeo URL slug.
-    string link?;
-    # The user's location.
-    string location?;
-    # The user's display name.
-    string name?;
-    # The default password for all future videos that this user uploads. To use this field, the `videos.privacy.view` field must be `password`.
-    string password?;
-    MeVideos videos?;
-};
-
 # Information about this user's portraits.
 public type UserMetadataConnectionsPictures record {
     # An array of HTTP methods permitted on this URI.
@@ -3109,24 +3031,6 @@ public type UserMetadataConnectionsPictures record {
     decimal total;
     # The API URI that resolves to the connection data.
     string uri;
-};
-
-public type Body14 record {
-    # The description of the new group.
-    string description?;
-    # The name of the new group.
-    string name;
-};
-
-public type Body13 record {
-    # Active text tracks appear in the player and are visible to other users. Only one text track per language can be active.
-    boolean active?;
-    # The language of the text track. For a complete list of valid languages, use the [/languages?filter=texttracks](https://developer.vimeo.com/api/endpoints/videos#GET/languages) endpoint.
-    string language;
-    # The name of the text track.
-    string name;
-    # The type of the text track.
-    string 'type;
 };
 
 # Information about the videos associated with this page.
@@ -3149,6 +3053,11 @@ public type OndemandpageMetadataConnectionsMetadataConnectionsVideos record {
 public type PurchaseinteractionBuy record {
     # Whether the On Demand video for purchase has DRM.
     boolean drm?;
+};
+
+public type CommentIdRepliesBody record {
+    # The reply to the comment.
+    string text;
 };
 
 # Information about the On Demand pages related to this group.
@@ -3289,6 +3198,11 @@ public type PurchaseinteractionSubscribe record {
     string? uri?;
 };
 
+public type AlbumIdVideosBody record {
+    # A comma-separated list of video URIs.
+    string videos;
+};
+
 # Data from video associated with version
 public type VideoversionsMetadataConnectionsVideo record {
     # An array of HTTP methods permitted on this URI.
@@ -3392,7 +3306,7 @@ public type Category record {
     # The display name that identifies the category.
     string name;
     # The container of this category's parent category, if the current category is a subcategory.
-    CategoryParent parent;
+    CategoryParent? parent;
     # The active picture for this category; defaults to vertical color bars.
     record {*Picture;} pictures;
     # The resource key of the category.
@@ -3480,6 +3394,15 @@ public type ChannelPrivacy record {
     string view;
 };
 
+public type PagesOndemandIdBody record {
+    # The custom string to use in this On Demand page's Vimeo URL.
+    string link?;
+    OndemandpagesondemandIdPreorder preorder?;
+    OndemandpagesondemandIdPublish publish?;
+    # Whether to publish the On Demand page automatically after all videos are finished transcoding.
+    boolean publish_when_ready?;
+};
+
 public type MevideosEmbedButtons record {
     # Show or hide the Embed button.
     boolean embed?;
@@ -3502,6 +3425,11 @@ public type OndemandgenreInteractions record {
     OndemandgenreInteractionsPage page;
 };
 
+public type PicturesPortraitsetIdBody record {
+    # Whether the picture is the user's active portrait.
+    boolean active?;
+};
+
 public type Credit record {
     # The name of the person credited.
     string name;
@@ -3513,6 +3441,13 @@ public type Credit record {
     record {*User;} user?;
     # The video associated with this credit.
     record {*Video;} video?;
+};
+
+public type VideoIdPicturesBody1 record {
+    # Whether the image created by the `time` field should be the default thumbnail for the video.
+    boolean active?;
+    # Creates an image of the video from the given time offset.
+    decimal time?;
 };
 
 # The Videos connection.
@@ -3571,6 +3506,17 @@ public type UserMetadataConnectionsShared record {
     string uri;
 };
 
+public type VideoIdCreditsBody record {
+    # The email address of the credited person.
+    string email;
+    # The name of the credited person.
+    string name;
+    # The role of the credited person.
+    string role;
+    # The URI of the Vimeo user who should be given credit in this video.
+    string user_uri;
+};
+
 # Information about the users that the current user is following.
 public type UserMetadataConnectionsFollowing record {
     # An array of HTTP methods permitted on this URI.
@@ -3581,6 +3527,11 @@ public type UserMetadataConnectionsFollowing record {
     string uri;
 };
 
+public type PicturesPortraitsetIdBody1 record {
+    # Whether the picture is the user's active portrait.
+    boolean active?;
+};
+
 # Information about the user's lifetime upload usage.
 public type UserUploadQuotaLifetime record {
     # The number of bytes remaining in your lifetime maximum.
@@ -3589,17 +3540,6 @@ public type UserUploadQuotaLifetime record {
     decimal? max;
     # The number of bytes that you've already uploaded against your lifetime limit.
     decimal? used;
-};
-
-public type Body record {
-    # The description of the channel.
-    string description?;
-    # The link to access the channel. You can use a custom name in the URL in place of a numeric channel ID, as in `/channels/{url_custom}`.
-    string link?;
-    # The name of the channel.
-    string name;
-    # The privacy level of the channel.
-    string privacy;
 };
 
 # Related content for this video.
@@ -3615,7 +3555,7 @@ public type AlbumMetadata record {
     # A collection of information that is connected to this resource.
     AlbumMetadataConnections connections;
     # A list of resource URIs related to the album.
-    AlbumMetadataInteractions interactions;
+    AlbumMetadataInteractions? interactions;
 };
 
 public type OndemandpagePublished record {
@@ -3706,6 +3646,23 @@ public type ChannelMetadataConnections record {
     ChannelMetadataConnectionsVideos videos;
 };
 
+public type CustomThumbnailsThumbnailIdBody record {
+    # Whether to make this the active album thumbnail.
+    boolean active?;
+};
+
+public type VideoIdPicturesBody record {
+    # Whether the image created by the `time` field should be the default thumbnail for the video.
+    boolean active?;
+    # Creates an image of the video from the given time offset.
+    decimal time?;
+};
+
+public type VideoIdSetAlbumThumbnailBody1 record {
+    # The video frame time in seconds to use as the album thumbnail.
+    decimal time_code?;
+};
+
 # Information about the videos contained within this group.
 public type GroupMetadataConnectionsVideos record {
     # An array of HTTP methods permitted on this URI.
@@ -3716,6 +3673,13 @@ public type GroupMetadataConnectionsVideos record {
     string uri;
 };
 
+public type GroupsBody record {
+    # The description of the new group.
+    string description?;
+    # The name of the new group.
+    string name;
+};
+
 # Information about the user's Watch Later interactions with this video.
 public type OndemandvideoMetadataInteractionsWatchlater record {
     # Whether the user has added this video to their Watch Later queue.
@@ -3724,6 +3688,11 @@ public type OndemandvideoMetadataInteractionsWatchlater record {
     string added_time;
     # The URI for the user to add this video to their Watch Later queue.
     string uri;
+};
+
+public type LogosLogoIdBody record {
+    # Whether to make this the active album logo.
+    boolean active?;
 };
 
 public type UserMetadataInteractionsAddPrivacyUser record {
@@ -3742,6 +3711,17 @@ public type VideosvideoIdversionsUpload record {
     string redirect_url?;
     # Upload size
     string size?;
+};
+
+public type VideoIdTexttracksBody record {
+    # Active text tracks appear in the player and are visible to other users. Only one text track per language can be active.
+    boolean active?;
+    # The language of the text track. For a complete list of valid languages, use the [/languages?filter=texttracks](https://developer.vimeo.com/api/endpoints/videos#GET/languages) endpoint.
+    string language;
+    # The name of the text track.
+    string name;
+    # The type of the text track.
+    string 'type;
 };
 
 # Information about the videos that belong to this album.
@@ -3772,6 +3752,11 @@ public type VideoMetadataInteractionsReport record {
     string[] reason;
     # The API URI that resolves to the connection data.
     string uri;
+};
+
+public type UserIdProjectsBody record {
+    # The name of the project.
+    string name;
 };
 
 # An action indicating if the authenticated user has followed this category.

--- a/openapi/vimeo/utils.bal
+++ b/openapi/vimeo/utils.bal
@@ -1,0 +1,217 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/url;
+
+type SimpleBasicType string|boolean|int|float|decimal;
+
+# Represents encoding mechanism details.
+type Encoding record {
+    # Defines how multiple values are delimited
+    string style = FORM;
+    # Specifies whether arrays and objects should generate as separate fields
+    boolean explode = true;
+    # Specifies the custom content type
+    string contentType?;
+    # Specifies the custom headers
+    map<any> headers?;
+};
+
+enum EncodingStyle {
+    DEEPOBJECT,
+    FORM,
+    SPACEDELIMITED,
+    PIPEDELIMITED
+}
+
+final Encoding & readonly defaultEncoding = {};
+
+# Serialize the record according to the deepObject style.
+#
+# + parent - Parent record name
+# + anyRecord - Record to be serialized
+# + return - Serialized record as a string
+isolated function getDeepObjectStyleRequest(string parent, record {} anyRecord) returns string {
+    string[] recordArray = [];
+    foreach [string, anydata] [key, value] in anyRecord.entries() {
+        if value is SimpleBasicType {
+            recordArray.push(parent + "[" + key + "]" + "=" + getEncodedUri(value.toString()));
+        } else if value is SimpleBasicType[] {
+            recordArray.push(getSerializedArray(parent + "[" + key + "]" + "[]", value, DEEPOBJECT, true));
+        } else if value is record {} {
+            string nextParent = parent + "[" + key + "]";
+            recordArray.push(getDeepObjectStyleRequest(nextParent, value));
+        } else if value is record {}[] {
+            string nextParent = parent + "[" + key + "]";
+            recordArray.push(getSerializedRecordArray(nextParent, value, DEEPOBJECT));
+        }
+        recordArray.push("&");
+    }
+    _ = recordArray.pop();
+    return string:'join("", ...recordArray);
+}
+
+# Serialize the record according to the form style.
+#
+# + parent - Parent record name
+# + anyRecord - Record to be serialized
+# + explode - Specifies whether arrays and objects should generate separate parameters
+# + return - Serialized record as a string
+isolated function getFormStyleRequest(string parent, record {} anyRecord, boolean explode = true) returns string {
+    string[] recordArray = [];
+    if explode {
+        foreach [string, anydata] [key, value] in anyRecord.entries() {
+            if (value is SimpleBasicType) {
+                recordArray.push(key, "=", getEncodedUri(value.toString()));
+            } else if (value is SimpleBasicType[]) {
+                recordArray.push(getSerializedArray(key, value, explode = explode));
+            } else if (value is record {}) {
+                recordArray.push(getFormStyleRequest(parent, value, explode));
+            }
+            recordArray.push("&");
+        }
+        _ = recordArray.pop();
+    } else {
+        foreach [string, anydata] [key, value] in anyRecord.entries() {
+            if (value is SimpleBasicType) {
+                recordArray.push(key, ",", getEncodedUri(value.toString()));
+            } else if (value is SimpleBasicType[]) {
+                recordArray.push(getSerializedArray(key, value, explode = false));
+            } else if (value is record {}) {
+                recordArray.push(getFormStyleRequest(parent, value, explode));
+            }
+            recordArray.push(",");
+        }
+        _ = recordArray.pop();
+    }
+    return string:'join("", ...recordArray);
+}
+
+# Serialize arrays.
+#
+# + arrayName - Name of the field with arrays
+# + anyArray - Array to be serialized
+# + style - Defines how multiple values are delimited
+# + explode - Specifies whether arrays and objects should generate separate parameters
+# + return - Serialized array as a string
+isolated function getSerializedArray(string arrayName, anydata[] anyArray, string style = "form", boolean explode = true) returns string {
+    string key = arrayName;
+    string[] arrayValues = [];
+    if (anyArray.length() > 0) {
+        if (style == FORM && !explode) {
+            arrayValues.push(key, "=");
+            foreach anydata i in anyArray {
+                arrayValues.push(getEncodedUri(i.toString()), ",");
+            }
+        } else if (style == SPACEDELIMITED && !explode) {
+            arrayValues.push(key, "=");
+            foreach anydata i in anyArray {
+                arrayValues.push(getEncodedUri(i.toString()), "%20");
+            }
+        } else if (style == PIPEDELIMITED && !explode) {
+            arrayValues.push(key, "=");
+            foreach anydata i in anyArray {
+                arrayValues.push(getEncodedUri(i.toString()), "|");
+            }
+        } else if (style == DEEPOBJECT) {
+            foreach anydata i in anyArray {
+                arrayValues.push(key, "[]", "=", getEncodedUri(i.toString()), "&");
+            }
+        } else {
+            foreach anydata i in anyArray {
+                arrayValues.push(key, "=", getEncodedUri(i.toString()), "&");
+            }
+        }
+        _ = arrayValues.pop();
+    }
+    return string:'join("", ...arrayValues);
+}
+
+# Serialize the array of records according to the form style.
+#
+# + parent - Parent record name
+# + value - Array of records to be serialized
+# + style - Defines how multiple values are delimited
+# + explode - Specifies whether arrays and objects should generate separate parameters
+# + return - Serialized record as a string
+isolated function getSerializedRecordArray(string parent, record {}[] value, string style = FORM, boolean explode = true) returns string {
+    string[] serializedArray = [];
+    if style == DEEPOBJECT {
+        int arayIndex = 0;
+        foreach var recordItem in value {
+            serializedArray.push(getDeepObjectStyleRequest(parent + "[" + arayIndex.toString() + "]", recordItem), "&");
+            arayIndex = arayIndex + 1;
+        }
+    } else {
+        if (!explode) {
+            serializedArray.push(parent, "=");
+        }
+        foreach var recordItem in value {
+            serializedArray.push(getFormStyleRequest(parent, recordItem, explode), ",");
+        }
+    }
+    _ = serializedArray.pop();
+    return string:'join("", ...serializedArray);
+}
+
+# Get Encoded URI for a given value.
+#
+# + value - Value to be encoded
+# + return - Encoded string
+isolated function getEncodedUri(string value) returns string {
+    string|error encoded = url:encode(value, "UTF8");
+    if (encoded is string) {
+        return encoded;
+    } else {
+        return value;
+    }
+}
+
+# Generate query path with query parameter.
+#
+# + queryParam - Query parameter map
+# + encodingMap - Details on serialization mechanism
+# + return - Returns generated Path or error at failure of client initialization
+isolated function getPathForQueryParam(map<anydata> queryParam, map<Encoding> encodingMap = {}) returns string|error {
+    string[] param = [];
+    if (queryParam.length() > 0) {
+        param.push("?");
+        foreach var [key, value] in queryParam.entries() {
+            if value is () {
+                _ = queryParam.remove(key);
+                continue;
+            }
+            Encoding encodingData = encodingMap.hasKey(key) ? encodingMap.get(key) : defaultEncoding;
+            if (value is SimpleBasicType) {
+                param.push(key, "=", getEncodedUri(value.toString()));
+            } else if (value is SimpleBasicType[]) {
+                param.push(getSerializedArray(key, value, encodingData.style, encodingData.explode));
+            } else if (value is record {}) {
+                if (encodingData.style == DEEPOBJECT) {
+                    param.push(getDeepObjectStyleRequest(key, value));
+                } else {
+                    param.push(getFormStyleRequest(key, value, encodingData.explode));
+                }
+            } else {
+                param.push(key, "=", value.toString());
+            }
+            param.push("&");
+        }
+        _ = param.pop();
+    }
+    string restOfPath = string:'join("", ...param);
+    return restOfPath;
+}


### PR DESCRIPTION
# Description
- When we tried to re-generate this connector with latest tool, got the following error. So, the irrelevant requestBody entries had to be removed from the openapi.yml
```
DELETE operation cannot have a requestBody. Error at operationId: removeChannelModerators
DELETE operation cannot have a requestBody. Error at operationId: removeVideosFromChannel
DELETE operation cannot have a requestBody. Error at operationId: deleteVodRegions
```

    

- After updating the openapi.yml, connector is re-generated.

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 