### PR TITLE
Regenerate Livestorm connector to handle null

### DIFF
--- a/openapi/livestorm/Ballerina.toml
+++ b/openapi/livestorm/Ballerina.toml
@@ -6,7 +6,7 @@ name = "livestorm"
 icon = "icon.png"
 distribution = "slbeta6"
 repository = "https://github.com/ballerina-platform/ballerinax-openapi-connectors"
-version = "1.1.1"
+version = "2.0.0"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/livestorm/Dependencies.toml
+++ b/openapi/livestorm/Dependencies.toml
@@ -272,7 +272,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "livestorm"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/livestorm/openapi.yml
+++ b/openapi/livestorm/openapi.yml
@@ -113,22 +113,22 @@ components:
       properties:
         copy_from_event_id:
           type: string
-          x-nullable: true
+          nullable: true
           description: Event ID to copy
           example: 356b514f-333e-47d5-b5f2-3a4278b14072
         owner_id:
           type: string
-          x-nullable: false
+          nullable: false
           description: Owner ID
           example: f035b51d-5135-47ee-b1fc-4e92508f312a
         title:
           type: string
-          x-nullable: false
+          nullable: false
           description: Event title
           example: New event
         slug:
           type: string
-          x-nullable: false
+          nullable: false
           description: Event slug
           example: my-awesome-slug
     SessionRequestAttribute:
@@ -137,11 +137,11 @@ components:
       properties:
         estimated_started_at:
           type: string
-          x-nullable: true
+          nullable: true
           description: Estimated started time
         timezone:
           type: string
-          x-nullable: false
+          nullable: false
           description: Time zone
     PeopleRequestAttribute:
       type: object
@@ -149,27 +149,27 @@ components:
       properties:
         referrer:
           type: string
-          x-nullable: true
+          nullable: true
           description: Referrer detail
         utm_source:
           type: string
-          x-nullable: false
+          nullable: false
           description: UTM tracking source
         utm_medium:
           type: string
-          x-nullable: true
+          nullable: true
           description: UTM medium
         utm_term:
           type: string
-          x-nullable: false
+          nullable: false
           description: UTM term
         utm_content:
           type: string
-          x-nullable: true
+          nullable: true
           description: UTM content
         utm_campaign:
           type: string
-          x-nullable: false
+          nullable: false
           description: UTM campaign
     OwnerAttribute:
       type: object
@@ -177,36 +177,35 @@ components:
       properties:
         role:
           type: string
-          x-nullable: false
+          nullable: false
           description: Role of owner
         created_at:
           type: integer
-          x-nullable: false
+          nullable: false
           description: Created timestamp
         updated_at:
           type: integer
-          x-nullable: false
+          nullable: false
           description: Updated timestamp
         timezone:
           type: string
-          x-nullable: false
+          nullable: false
           description: Timezone
         first_name:
           type: string
-          x-nullable: false
+          nullable: false
           description: First name
         last_name:
           type: string
-          x-nullable: false
+          nullable: false
           description: Last name
         email:
           type: string
-          x-nullable: false
+          nullable: false
           description: Email
         avatar_link:
           type: string
-          x-nullable: false
-          nullable: true
+          nullable: false
           description: Avatar link
     EventAttribute:
       type: object
@@ -214,72 +213,71 @@ components:
       properties:
         title:
           type: string
-          x-nullable: false
+          nullable: false
           description: Event title
           example: New event
         slug:
           type: string
-          x-nullable: false
+          nullable: false
           description: Event slug
           example: my-awesome-slug
         registration_link:
           type: string
-          x-nullable: true
+          nullable: true
           description: Event title
           example: https://app.livestorm.co/p/4d584b01-6319-4d19-a420-c67156273b76
         estimated_duration:
           type: integer
-          x-nullable: true
+          nullable: true
           description: Estimated duration
           example: 20      
         registration_page_enabled:
           type: boolean
-          x-nullable: true
+          nullable: true
           description: Registration page enabled or not
           example: true
         everyone_can_speak:
           type: boolean
-          x-nullable: true
+          nullable: true
           description: Everyone can speack or not
           example: true    
         description:
           type: string
-          x-nullable: true
           nullable: true
           description: Description about event
           example: It is a webinar
         language:
           type: string
-          x-nullable: true
+          nullable: true
           description: Event language
           example: en      
         published_at:
           type: integer
-          x-nullable: true
+          nullable: true
           description: Updated timestamp
           example: 1625606595
         created_at:
           type: integer
-          x-nullable: true
+          nullable: true
           description: Created timestamp
           example: 1625606595  
         updated_at:
           type: integer
-          x-nullable: true
+          nullable: true
           description: Updated timestamp
           example: 1625606595       
         owner:
           "$ref": "#/components/schemas/Owner"
         sessions_count:
           type: integer
-          x-nullable: true
+          nullable: true
           description: Number of sessions
           example: 1  
         fields:
           type: array
           items:
             "$ref": "#/components/schemas/Field"
-          x-nullable: true
+          nullable: true
           description: Fields available
     Field:
       type: object
@@ -287,22 +285,22 @@ components:
       properties:
         id:
           type: string
-          x-nullable: true
+          nullable: true
           description: Event field ID
           example: email  
         type:
           type: string
-          x-nullable: true
+          nullable: true
           description: Type of fields
           example: text  
         order:
           type: integer
-          x-nullable: true
+          nullable: true
           description: Order of fields
           example: 1  
         required:
           type: boolean
-          x-nullable: true
+          nullable: true
           description: Required or not
           example: true  
     EventRelationship:
@@ -313,7 +311,7 @@ components:
           type: array
           items:
             "$ref": "#/components/schemas/Session"
-          x-nullable: true
+          nullable: true
           description: Event session
     SessionRelationship:
       type: object
@@ -323,7 +321,7 @@ components:
           type: array
           items:
             "$ref": "#/components/schemas/People"
-          x-nullable: true
+          nullable: true
           description: People
     Session:
       type: object
@@ -331,11 +329,11 @@ components:
       properties:
         type:
           type: string
-          x-nullable: false
+          nullable: false
           description: Session type
         id:
           type: string
-          x-nullable: false
+          nullable: false
           description: Session ID
         attributes:
           "$ref": "#/components/schemas/SessionAttribute"
@@ -388,11 +386,11 @@ components:
       properties:
         type:
           type: string
-          x-nullable: false
+          nullable: false
           description: People type
         id:
           type: string
-          x-nullable: false
+          nullable: false
           description: People ID
         attributes:
           "$ref": "#/components/schemas/PeopleAttribute"
@@ -826,55 +824,55 @@ paths:
                             properties:
                               event_type_id:
                                 type: string
-                                x-nullable: true
+                                nullable: true
                                 description: ''
                               status:
                                 type: string
-                                x-nullable: false
+                                nullable: false
                                 description: ''
                               timezone:
                                 type: string
-                                x-nullable: false
+                                nullable: false
                                 description: ''
                               room_link:
                                 type: string
-                                x-nullable: false
+                                nullable: false
                                 description: ''
                               attendees_count:
                                 type: integer
-                                x-nullable: false
+                                nullable: false
                                 description: ''
                               duration:
                                 type: integer
-                                x-nullable: true
+                                nullable: true
                                 description: ''
                               estimated_started_at:
                                 type: integer
-                                x-nullable: false
+                                nullable: false
                                 description: ''
                               started_at:
                                 type: integer
-                                x-nullable: true
+                                nullable: true
                                 description: ''
                               ended_at:
                                 type: integer
-                                x-nullable: true
+                                nullable: true
                                 description: ''
                               canceled_at:
                                 type: integer
-                                x-nullable: true
+                                nullable: true
                                 description: ''
                               created_at:
                                 type: integer
-                                x-nullable: false
+                                nullable: false
                                 description: ''
                               updated_at:
                                 type: integer
-                                x-nullable: false
+                                nullable: false
                                 description: ''
                               registrants_count:
                                 type: integer
-                                x-nullable: true
+                                nullable: true
                                 description: ''
                   meta:
                     "$ref": "#/components/schemas/Meta"
@@ -1282,93 +1280,93 @@ paths:
                             properties:
                               role:
                                 type: string
-                                x-nullable: false
+                                nullable: false
                                 description: ''
                               created_at:
                                 type: integer
-                                x-nullable: true
+                                nullable: true
                                 description: ''
                               updated_at:
                                 type: integer
-                                x-nullable: true
+                                nullable: true
                                 description: ''
                               timezone:
                                 type: string
-                                x-nullable: true
+                                nullable: true
                                 description: ''
                               first_name:
                                 type: string
-                                x-nullable: true
+                                nullable: true
                                 description: ''
                               last_name:
                                 type: string
-                                x-nullable: true
+                                nullable: true
                                 description: ''
                               email:
                                 type: string
-                                x-nullable: true
+                                nullable: true
                                 description: ''
                               avatar_link:
                                 type: string
-                                x-nullable: true
+                                nullable: true
                                 description: ''
                               registrant_detail:
                                 type: object
-                                x-nullable: true
+                                nullable: true
                                 description: ''
                                 items:
                                   type: object
                                   properties:
                                     event_id:
                                       type: string
-                                      x-nullable: false
+                                      nullable: false
                                       description: ''
                                     created_at:
                                       type: string
-                                      x-nullable: false
+                                      nullable: false
                                       description: ''
                                     updated_at:
                                       type: string
-                                      x-nullable: false
+                                      nullable: false
                                       description: ''
                                     fields:
                                       type: array
-                                      x-nullable: false
+                                      nullable: false
                                       description: ''
                                       items:
                                         type: object
                                         properties:
                                           id:
                                             type: string
-                                            x-nullable: false
+                                            nullable: false
                                             description: ''
                                           type:
                                             type: string
-                                            x-nullable: false
+                                            nullable: false
                                             description: ''
                                           order:
                                             type: integer
-                                            x-nullable: false
+                                            nullable: false
                                             description: ''
                                           required:
                                             type: string
-                                            x-nullable: false
+                                            nullable: false
                                             description: ''
                               messages_count:
                                 type: integer
-                                x-nullable: false
+                                nullable: false
                                 description: ''
                               questions_count:
                                 type: integer
-                                x-nullable: false
+                                nullable: false
                                 description: ''
                               votes_count:
                                 type: integer
-                                x-nullable: false
+                                nullable: false
                                 description: ''
                               up_votes_count:
                                 type: integer
-                                x-nullable: false
+                                nullable: false
                                 description: ''
                   meta:
                     "$ref": "#/components/schemas/Meta"

--- a/openapi/livestorm/types.bal
+++ b/openapi/livestorm/types.bal
@@ -37,7 +37,7 @@ public type Owner record {
 # Session releationship
 public type SessionRelationship record {
     # People
-    People[] people?;
+    People[]? people?;
 };
 
 # Create new event response
@@ -60,29 +60,29 @@ public type EventAttribute record {
     # Event slug
     string slug?;
     # Event title
-    string registration_link?;
+    string? registration_link?;
     # Estimated duration
-    int estimated_duration?;
+    int? estimated_duration?;
     # Registration page enabled or not
-    boolean registration_page_enabled?;
+    boolean? registration_page_enabled?;
     # Everyone can speack or not
-    boolean everyone_can_speak?;
+    boolean? everyone_can_speak?;
     # Description about event
     string? description?;
     # Event language
-    string language?;
+    string? language?;
     # Updated timestamp
-    int published_at?;
+    int? published_at?;
     # Created timestamp
-    int created_at?;
+    int? created_at?;
     # Updated timestamp
-    int updated_at?;
+    int? updated_at?;
     # Owner details
     Owner owner?;
     # Number of sessions
-    int sessions_count?;
+    int? sessions_count?;
     # Fields available
-    Field[] fields?;
+    Field[]? fields?;
 };
 
 # Add Session data
@@ -108,27 +108,27 @@ public type EventData record {
 # Event fields
 public type Field record {
     # Event field ID
-    string id?;
+    string? id?;
     # Type of fields
-    string 'type?;
+    string? 'type?;
     # Order of fields
-    int 'order?;
+    int? 'order?;
     # Required or not
-    boolean required?;
+    boolean? required?;
 };
 
 # People request attributes
 public type PeopleRequestAttribute record {
     # Referrer detail
-    string referrer?;
+    string? referrer?;
     # UTM tracking source
     string utm_source?;
     # UTM medium
-    string utm_medium?;
+    string? utm_medium?;
     # UTM term
     string utm_term?;
     # UTM content
-    string utm_content?;
+    string? utm_content?;
     # UTM campaign
     string utm_campaign?;
 };
@@ -162,19 +162,19 @@ public type OwnerAttribute record {
     # Email
     string email?;
     # Avatar link
-    string? avatar_link?;
+    string avatar_link?;
 };
 
 # Event releationship
 public type EventRelationship record {
     # Event session
-    Session[] sessions?;
+    Session[]? sessions?;
 };
 
 # Session request attributes
 public type SessionRequestAttribute record {
     # Estimated started time
-    string estimated_started_at?;
+    string? estimated_started_at?;
     # Time zone
     string timezone?;
 };
@@ -286,7 +286,7 @@ public type InlineResponse2003 record {
     record {
         *Event;
         # Attributes
-        record {string role?; int created_at?; int updated_at?; string timezone?; string first_name?; string last_name?; string email?; string avatar_link?; record {string event_id?; string created_at?; string updated_at?; record {string id?; string 'type?; int 'order?; string required?;}[] fields?;}[] registrant_detail?; int messages_count?; int questions_count?; int votes_count?; int up_votes_count?;} attributes?;
+        record {string role?; int? created_at?; int? updated_at?; string? timezone?; string? first_name?; string? last_name?; string? email?; string? avatar_link?; record {string event_id?; string created_at?; string updated_at?; record {string id?; string 'type?; int 'order?; string required?;}[] fields?;}[]? registrant_detail?; int messages_count?; int questions_count?; int votes_count?; int up_votes_count?;} attributes?;
     }[] data;
     # Metadata
     Meta meta?;
@@ -297,7 +297,7 @@ public type InlineResponse2002 record {
     record {
         *Event;
         # Attributes
-        record {string event_type_id?; string status?; string timezone?; string room_link?; int attendees_count?; int duration?; int estimated_started_at?; int started_at?; int ended_at?; int canceled_at?; int created_at?; int updated_at?; int registrants_count?;} attributes?;
+        record {string? event_type_id?; string status?; string timezone?; string room_link?; int attendees_count?; int? duration?; int estimated_started_at?; int? started_at?; int? ended_at?; int? canceled_at?; int created_at?; int updated_at?; int? registrants_count?;} attributes?;
     }[] data;
     # Metadata
     Meta meta?;
@@ -306,7 +306,7 @@ public type InlineResponse2002 record {
 # Event request attributes
 public type EventRequestAttribute record {
     # Event ID to copy
-    string copy_from_event_id?;
+    string? copy_from_event_id?;
     # Owner ID
     string owner_id?;
     # Event title


### PR DESCRIPTION
# Description

Regenerate `Livestorm` connector using Ballerina SL Beta6

Changes were added to OpenAPI specification of the Livestorm connector due to nullable fields in return for response not mapped properly earlier.
Fixes https://github.com/ballerina-platform/ballerina-extended-library/issues/233

One line release note: 
- Regenerate `Livestorm` connector using Ballerina SL Beta6

## Type of change

- [x] Bug fix (Breaking change which fixes an issue)

# How Has This Been Tested?

Not tested

# Checklist:

### Changes to OpenAPI definition
### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 