### PR TITLE
Add nullable field to avatar_link attribute

### DIFF
--- a/openapi/livestorm/Dependencies.toml
+++ b/openapi/livestorm/Dependencies.toml
@@ -272,7 +272,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "livestorm"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/livestorm/openapi.yml
+++ b/openapi/livestorm/openapi.yml
@@ -205,7 +205,7 @@ components:
           description: Email
         avatar_link:
           type: string
-          nullable: false
+          nullable: true
           description: Avatar link
     EventAttribute:
       type: object

--- a/openapi/livestorm/types.bal
+++ b/openapi/livestorm/types.bal
@@ -162,7 +162,7 @@ public type OwnerAttribute record {
     # Email
     string email?;
     # Avatar link
-    string avatar_link?;
+    string? avatar_link?;
 };
 
 # Event releationship


### PR DESCRIPTION
# Description

Regenerate `Livestorm` connector using Ballerina SL Beta6

Changes were added to OpenAPI specification of the Livestorm connector due to nullable fields in return for response not mapped properly earlier.

One line release note: 
- Regenerate `Livestorm` connector using Ballerina SL Beta6

## Type of change

- [x] Bug fix (Non-Breaking change which fixes an issue)

# How Has This Been Tested?

Not tested

# Checklist:

### Changes to OpenAPI definition
### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 