### PR TITLE
[Livestorm connector] Fix data type mismatches between response and records

### DIFF
--- a/openapi/livestorm/Ballerina.toml
+++ b/openapi/livestorm/Ballerina.toml
@@ -6,7 +6,7 @@ name = "livestorm"
 icon = "icon.png"
 distribution = "slbeta6"
 repository = "https://github.com/ballerina-platform/ballerinax-openapi-connectors"
-version = "2.0.0"
+version = "2.0.2"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/livestorm/Dependencies.toml
+++ b/openapi/livestorm/Dependencies.toml
@@ -88,6 +88,9 @@ dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
 ]
+modules = [
+	{org = "ballerina", packageName = "io", moduleName = "io"}
+]
 
 [[package]]
 org = "ballerina"
@@ -240,6 +243,18 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "test"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "test", moduleName = "test"}
+]
+
+[[package]]
+org = "ballerina"
 name = "time"
 version = "2.1.0"
 dependencies = [
@@ -272,9 +287,11 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "livestorm"
-version = "2.0.0"
+version = "2.0.2"
 dependencies = [
 	{org = "ballerina", name = "http"},
+	{org = "ballerina", name = "io"},
+	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "url"},
 	{org = "ballerinai", name = "observe"}
 ]

--- a/openapi/livestorm/openapi.yml
+++ b/openapi/livestorm/openapi.yml
@@ -205,7 +205,7 @@ components:
           description: Email
         avatar_link:
           type: string
-          nullable: false
+          nullable: true
           description: Avatar link
     EventAttribute:
       type: object
@@ -372,10 +372,10 @@ components:
           type: string
           description: Canceled time
         created_at:
-          type: string
+          type: integer
           description: Created time
         updated_at:
-          type: string
+          type: integer
           description: Updated time
         registrants_count:
           type: string
@@ -402,10 +402,10 @@ components:
           type: string
           description: Role assigned to
         created_at:
-          type: string
+          type: integer
           description: Created time
         updated_at:
-          type: string
+          type: integer
           description: Updated time
         timezone:
           type: string
@@ -1314,44 +1314,42 @@ paths:
                                 type: object
                                 nullable: true
                                 description: ''
-                                items:
-                                  type: object
-                                  properties:
-                                    event_id:
-                                      type: string
-                                      nullable: false
-                                      description: ''
-                                    created_at:
-                                      type: string
-                                      nullable: false
-                                      description: ''
-                                    updated_at:
-                                      type: string
-                                      nullable: false
-                                      description: ''
-                                    fields:
-                                      type: array
-                                      nullable: false
-                                      description: ''
-                                      items:
-                                        type: object
-                                        properties:
-                                          id:
-                                            type: string
-                                            nullable: false
-                                            description: ''
-                                          type:
-                                            type: string
-                                            nullable: false
-                                            description: ''
-                                          order:
-                                            type: integer
-                                            nullable: false
-                                            description: ''
-                                          required:
-                                            type: string
-                                            nullable: false
-                                            description: ''
+                                properties:
+                                  event_id:
+                                    type: string
+                                    nullable: false
+                                    description: ''
+                                  created_at:
+                                    type: integer
+                                    nullable: false
+                                    description: ''
+                                  updated_at:
+                                    type: integer
+                                    nullable: false
+                                    description: ''
+                                  fields:
+                                    type: array
+                                    nullable: false
+                                    description: ''
+                                    items:
+                                      type: object
+                                      properties:
+                                        id:
+                                          type: string
+                                          nullable: false
+                                          description: ''
+                                        type:
+                                          type: string
+                                          nullable: false
+                                          description: ''
+                                        value:
+                                          type: string
+                                          nullable: true
+                                          description: ''
+                                        required:
+                                          type: boolean
+                                          nullable: false
+                                          description: ''
                               messages_count:
                                 type: integer
                                 nullable: false

--- a/openapi/livestorm/types.bal
+++ b/openapi/livestorm/types.bal
@@ -162,7 +162,7 @@ public type OwnerAttribute record {
     # Email
     string email?;
     # Avatar link
-    string avatar_link?;
+    string? avatar_link?;
 };
 
 # Event releationship
@@ -184,9 +184,9 @@ public type PeopleAttribute record {
     # Role assigned to
     string role?;
     # Created time
-    string created_at?;
+    int created_at?;
     # Updated time
-    string updated_at?;
+    int updated_at?;
     # Time zone
     string timezone?;
     # First name
@@ -238,9 +238,9 @@ public type SessionAttribute record {
     # Canceled time
     string canceled_at?;
     # Created time
-    string created_at?;
+    int created_at?;
     # Updated time
-    string updated_at?;
+    int updated_at?;
     # Number of registrants
     string registrants_count?;
 };
@@ -286,7 +286,7 @@ public type InlineResponse2003 record {
     record {
         *Event;
         # Attributes
-        record {string role?; int? created_at?; int? updated_at?; string? timezone?; string? first_name?; string? last_name?; string? email?; string? avatar_link?; record {string event_id?; string created_at?; string updated_at?; record {string id?; string 'type?; int 'order?; string required?;}[] fields?;}[]? registrant_detail?; int messages_count?; int questions_count?; int votes_count?; int up_votes_count?;} attributes?;
+        record {string role?; int? created_at?; int? updated_at?; string? timezone?; string? first_name?; string? last_name?; string? email?; string? avatar_link?; record {string event_id?; int created_at?; int updated_at?; record {string id?; string 'type?; string? value?; boolean required?;}[] fields?;} registrant_detail?; int messages_count?; int questions_count?; int votes_count?; int up_votes_count?;} attributes?;
     }[] data;
     # Metadata
     Meta meta?;


### PR DESCRIPTION
# Description

Regenerate `Livestorm` connector using Ballerina SL Beta6

Changes were added to the OpenAPI specification of the Livestorm connector due to a mismatch in the data types returned in the response and the data type mentioned in the official OpenAPI. Although it is an official OpenApi from Livestorm. Data types returned are different in the actual response.

One line release note: 
- Regenerate `Livestorm` connector using Ballerina SL Beta6

## Type of change

- [x] Bug fix (Non-Breaking change which fixes an issue)

# How Has This Been Tested?

Not tested

# Checklist:

### Changes to OpenAPI definition
### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 