### PR TITLE
Bump `actions/checkout` version to `v2`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       image: ballerina/ballerina:nightly
       options: --user root
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Build with Gradle
         env:
           BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -12,7 +12,7 @@ jobs:
       image: ballerina/ballerina:nightly
       options: --user root
     steps:
-      - uses: actions/checkout@v1   
+      - uses: actions/checkout@v2   
       - name: Build with Gradle
         env:
           BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}


### PR DESCRIPTION
# Description
- Bump `actions/checkout` version to the latest version (`v2`) in the github workflows

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 