### PR TITLE
Remove irrelevant slash in the service url of hubspot.crm.contact connector

### DIFF
--- a/openapi/hubspot.crm.contact/client.bal
+++ b/openapi/hubspot.crm.contact/client.bal
@@ -63,7 +63,7 @@ public isolated client class Client {
     # + clientConfig - The configurations to be used when initializing the `connector` 
     # + serviceUrl - URL of the target service 
     # + return - An error if connector initialization failed 
-    public isolated function init(ClientConfig clientConfig, string serviceUrl = "https://api.hubapi.com/") returns error? {
+    public isolated function init(ClientConfig clientConfig, string serviceUrl = "https://api.hubapi.com") returns error? {
         http:Client httpEp = check new (serviceUrl, clientConfig);
         self.clientEp = httpEp;
         return;

--- a/openapi/hubspot.crm.contact/openapi.yaml
+++ b/openapi/hubspot.crm.contact/openapi.yaml
@@ -14,7 +14,7 @@ info:
 
     Create a [HubSpot account](https://www.hubspot.com/) and obtain OAuth tokens following [this guide](https://developers.hubspot.com/docs/api/working-with-oauth4).
 servers:
-  - url: 'https://api.hubapi.com/'
+  - url: 'https://api.hubapi.com'
 tags:
   - name: Basic
   - name: Search


### PR DESCRIPTION
# Description
- Remove irrelevant slash in the hubspot service url

One line release note: 
- Remove irrelevant slash in the hubspot service url

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 