### PR TITLE
Fix record mapping issue

### DIFF
--- a/openapi/aayu.mftg.as2/Dependencies.toml
+++ b/openapi/aayu.mftg.as2/Dependencies.toml
@@ -282,7 +282,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "aayu.mftg.as2"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "io"},

--- a/openapi/aayu.mftg.as2/openapi.yaml
+++ b/openapi/aayu.mftg.as2/openapi.yaml
@@ -1692,9 +1692,6 @@ components:
     # Send message
     SuccessfulMessageSubmitResponse:
       title: Successful Message Submission Response
-      required:
-        - message
-        - as2MessageId
       type: object
       properties:
         message:

--- a/openapi/aayu.mftg.as2/types.bal
+++ b/openapi/aayu.mftg.as2/types.bal
@@ -36,8 +36,8 @@ public type MdnMessage record {
 };
 
 public type SuccessfulMessageSubmitResponse record {
-    string message;
-    string as2MessageId;
+    string message?;
+    string as2MessageId?;
 };
 
 public type Attachment record {


### PR DESCRIPTION
# Description

Fix record mapping issue.

`SuccessfulMessageSubmitResponse` should have optional fields.

```
public type SuccessfulMessageSubmitResponse record {
    string message?;
    string as2MessageId?;
};
```

### Security checks
 - [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 