### PR TITLE
Update hashes and bump versions after v2.2.8 release

### DIFF
--- a/openapi.properties
+++ b/openapi.properties
@@ -1,10 +1,10 @@
-#Thu Jun 09 09:02:17 IST 2022
-openapi/soundcloud=9a68a3b13c7727cbee7d909490a86448
-openapi/iris.disputeresponder=c893b56cd2f7fc273d8af2f4211f732f
-openapi/ebay.recommendation=10479509bcd73f42421375047b03a3e9
+#Thu Aug 04 23:30:45 IST 2022
 openapi/earthref.fiesta=9122b948cc69e92c86db457effc12d6e
-openapi/nytimes.mostpopular=e7aae4d66b8c26ad0544c98405830e7c
+openapi/ebay.recommendation=10479509bcd73f42421375047b03a3e9
+openapi/iris.disputeresponder=c893b56cd2f7fc273d8af2f4211f732f
+openapi/soundcloud=9a68a3b13c7727cbee7d909490a86448
 openapi/rumble.run=1fe8f5adc8a4d5a8e82cac0ca19a3f70
+openapi/nytimes.mostpopular=e7aae4d66b8c26ad0544c98405830e7c
 openapi/covid19=84bcb2a8ffccdab12725b550027dfd96
 openapi/azure.textanalytics=ae4f383ef4a48b8d7189395c32d30f44
 openapi/chaingateway=c66a61e0cad244edce2cd3de29eb2925
@@ -132,7 +132,7 @@ openapi/eventbrite=02c7ab94aa0e91814216c2b4e4797f4b
 openapi/sinch.voice=2d22fcf6cb55f4fac36ff0b0cb5f4253
 openapi/mathtools.numbers=016bccbea1e4711ec4b93547d57d7113
 openapi/ebay.analytics=72b267520d6ce3114b8aa2a085e67cc4
-openapi/quickbooks.online=31fd035377b53c1a90b706dcc3218ca8
+openapi/quickbooks.online=80266c458c75e2ca80c42a8e636e4776
 openapi/godaddy.certificates=bbc5ff123a31b5b54dcf32a0ed82fd14
 openapi/tableau=67f7be7869a7c52039f0148907b8b1f3
 openapi/godaddy.shopper=81ca10d5f8c544ae764ae8b6f309060f
@@ -339,7 +339,7 @@ openapi/bulksms=9cea3ea19ee53813e209e282d02f5915
 openapi/webscraping.ai=7e293217ee9b0273907896930e181fb5
 openapi/saps4hana.itcm.product=2f7bc38cb73506af3f209a3e32be0722
 openapi/pdfbroker=38b71b9f215a3b182e1327112918a1f4
-openapi/alfresco=6be5f826d0dbdbb5c75a99d4adaf67ab
+openapi/alfresco=7c71dbdc40a978d2a3e8e2883f6c5c28
 openapi/ebay.listing=6d096ec02a4de7d7906861afbc4851a1
 openapi/googleapis.cloudfilestore=3b93f7b3df648598c3073fa66454ebe3
 openapi/namsor=c13df9fab08b7868ab3430bbd623b733

--- a/openapi/alfresco/Ballerina.toml
+++ b/openapi/alfresco/Ballerina.toml
@@ -6,7 +6,7 @@ name = "alfresco"
 icon = "icon.png"
 distribution = "2201.0.0"
 repository = "https://github.com/ballerina-platform/ballerinax-openapi-connectors"
-version = "1.0.1"
+version = "1.0.2"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/quickbooks.online/Ballerina.toml
+++ b/openapi/quickbooks.online/Ballerina.toml
@@ -6,7 +6,7 @@ name = "quickbooks.online"
 icon = "icon.png"
 distribution = "2201.1.1"
 repository = "https://github.com/ballerina-platform/ballerinax-openapi-connectors"
-version = "1.2.2"
+version = "1.2.3"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true


### PR DESCRIPTION
# Description
We released 2 connectors in this release https://github.com/ballerina-platform/openapi-connectors/releases/tag/v2.2.8
| Connector Name | Version |
| ---------------- | ------- |
| alfresco |1.0.1|
|quickbooks.online|1.2.2|

This PR is to do the version bump and hash update after the release.