### PR TITLE
Remove central token from daily build workflow

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: actions/checkout@v2   
       - name: Build with Gradle
         env:
-          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}
           JAVA_OPTS: -DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true
           GRADLE_USER_HOME: ~/.gradle
         run: |


### PR DESCRIPTION
- Remove central token from daily build workflow