### PR TITLE
Point to prod central in ci.yaml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,6 @@ on: [push, pull_request]
 jobs:
   container:
     runs-on: ubuntu-latest
-    # TODO: This is a temp fix to use DEV env while building PRs 
-    env: 
-     BALLERINA_DEV_CENTRAL: true
     container:
       image: ballerina/ballerina:2201.2.1
       options: --user root


### PR DESCRIPTION
# Description
Earlier we added a temperorary fix to point to dev BCentral in the ci.yaml via https://github.com/ballerina-platform/openapi-connectors/pull/738
https://github.com/ballerina-platform/openapi-connectors/pull/738#issuecomment-1291365462

This PR is to remove that temporary fix and point to the Prod BCentral