### PR TITLE
Add remote operation to get usage_record_summaries

### DIFF
--- a/openapi/stripe/Ballerina.toml
+++ b/openapi/stripe/Ballerina.toml
@@ -4,9 +4,9 @@ keywords = ["Finance/Payment", "Cost/Freemium"]
 org = "ballerinax"
 name = "stripe"
 icon = "icon.png"
-distribution = "2201.2.1"
+distribution = "2201.3.2"
 repository = "https://github.com/ballerina-platform/ballerinax-openapi-connectors"
-version = "1.4.1"
+version = "1.5.0"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/stripe/Dependencies.toml
+++ b/openapi/stripe/Dependencies.toml
@@ -9,7 +9,7 @@ dependencies-toml-version = "2"
 [[package]]
 org = "ballerina"
 name = "auth"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -22,8 +22,9 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.2.2"
+version = "3.3.0"
 dependencies = [
+	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "task"},
 	{org = "ballerina", name = "time"}
@@ -32,7 +33,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "constraint"
-version = "1.0.0"
+version = "1.0.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -40,7 +41,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.2.2"
+version = "2.3.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -49,7 +50,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -62,7 +63,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.4.0"
+version = "2.5.3"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -93,7 +94,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -107,7 +108,7 @@ version = "0.0.0"
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -160,6 +161,14 @@ version = "0.0.0"
 
 [[package]]
 org = "ballerina"
+name = "lang.regexp"
+version = "0.0.0"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.runtime"
 version = "0.0.0"
 dependencies = [
@@ -171,7 +180,8 @@ org = "ballerina"
 name = "lang.string"
 version = "0.0.0"
 dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.regexp"}
 ]
 
 [[package]]
@@ -185,7 +195,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.4.1"
+version = "2.5.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -196,7 +206,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.4.0"
+version = "2.5.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -206,7 +216,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -218,7 +228,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -226,7 +236,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"}
@@ -235,7 +245,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "regex"
-version = "1.3.0"
+version = "1.3.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.string"}
@@ -244,7 +254,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.2.2"
+version = "2.3.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -253,7 +263,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -261,7 +271,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -284,7 +294,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "stripe"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "url"},

--- a/openapi/stripe/Package.md
+++ b/openapi/stripe/Package.md
@@ -9,7 +9,7 @@ This package provides the capability to easily access Zoom API's meeting and web
 #### Compatibility
 |                               | Version                       |
 |-------------------------------|-------------------------------|
-| Ballerina Language Version    | Ballerina Swan Lake 2201.2.1    |
+| Ballerina Language Version    | Ballerina Swan Lake 2201.3.2    |
 | API Version                   | v1                            |
 
 ## Report issues

--- a/openapi/stripe/client.bal
+++ b/openapi/stripe/client.bal
@@ -530,6 +530,25 @@ public isolated client class Client {
         UsageRecord response = check self.clientEp->post(resourcePath, request);
         return response;
     }
+    
+    # <p>For the specified subscription item, returns a list of summary objects. Each object in the list provides usage information that’s been summarized from multiple usage records and over a subscription billing period (e.g., 15 usage records in the month of September).</p>
+    # 
+    # <p>The list is sorted in reverse-chronological order (newest first). The first list item represents the most current usage period that hasn’t ended yet. Since new usage records can still be added, the returned summary information for the subscription item’s ID should be seen as unstable until the subscription billing period ends.</p>
+    #
+    # + endingBefore - A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. 
+    # + expand - Specifies which fields in the response should be expanded. 
+    # + 'limit - A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. 
+    # + startingAfter - A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. 
+    # + return - Successful response. 
+    remote isolated function getSubscriptionItemsSubscriptionItemUsageRecordSummaries(string subscriptionItem, string? endingBefore = (), string[]? expand = (), int? 'limit = (), string? startingAfter = ()) returns UsageEventsResourceUsageRecordSummaryList|error {
+        string resourcePath = string `/v1/subscription_items/${getEncodedUri(subscriptionItem)}/usage_record_summaries`;
+        map<anydata> queryParam = {"ending_before": endingBefore, "expand": expand, "limit": 'limit, "starting_after": startingAfter};
+        map<Encoding> queryParamEncoding = {"expand": {style: DEEPOBJECT, explode: true}};
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam, queryParamEncoding);
+        UsageEventsResourceUsageRecordSummaryList response = check self.clientEp->get(resourcePath);
+        return response;
+    }
+
     # <p>By default, returns a list of subscriptions that have not been canceled. In order to list canceled subscriptions, specify <code>status=canceled</code>.</p>
     #
     # + collectionMethod - The collection method of the subscriptions to retrieve. Either `charge_automatically` or `send_invoice`. 

--- a/openapi/stripe/types.bal
+++ b/openapi/stripe/types.bal
@@ -1365,6 +1365,17 @@ public type PaymentMethodDetailsInteracPresent record {
 };
 
 # 
+public type UsageEventsResourceUsageRecordSummaryList record {
+    UsageRecordSummary[]? data;
+    # True if this list has another page of items after this one that can be fetched.
+    boolean? has_more;
+    # String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+    string? 'object;
+    # The URL where this list can be accessed.
+    string? url;
+};
+
+# 
 public type DeletedSubscriptionItem record {
     # Always true for a deleted object
     boolean? deleted;


### PR DESCRIPTION
# Description

Including ability to call
`GET /v1/subscription_items/:id/usage_record_summaries`


Related issue: https://github.com/wso2-enterprise/choreo/issues/18935


One line release note: 
- Add remote operation to retrieve usage_record_summaries for stripe connector

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

N/A

**Test Configuration**:
* Ballerina Version: 2201.2.3


# Checklist:

### Changes to OpenAPI definition

- [x] Modified `info` section of the OpenAPI definition file - [Example](https://github.com/ballerina-platform/ballerina-extended-library/discussions/74)

    - `description` - what the connector is about 
    - `x-ballerina-init-description` OpenAPI extension - connector initialization details 
    - `x-ballerina-display` OpenAPI extension - connector name and path to the connector icon 

- [x] Added proper description each API Key, if API Key authentication is defined in OpenAPI definition file 

### Verifying connector module

- [x] Compiled the connector successfully with the targeted ballerina version. 
- [x] Conducted smoke tests on the connector (Recommended when OpenAPI definition is obtain from an unofficial source)

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 