### PR TITLE
Add remote operation to get usage_record_summaries

### DIFF
--- a/openapi/stripe/client.bal
+++ b/openapi/stripe/client.bal
@@ -542,6 +542,25 @@ public isolated client class Client {
         UsageRecord response = check self.clientEp->post(resourcePath, request);
         return response;
     }
+
+    # <p>For the specified subscription item, returns a list of summary objects. Each object in the list provides usage information that’s been summarized from multiple usage records and over a subscription billing period (e.g., 15 usage records in the month of September).</p>
+    #
+    # <p>The list is sorted in reverse-chronological order (newest first). The first list item represents the most current usage period that hasn’t ended yet. Since new usage records can still be added, the returned summary information for the subscription item’s ID should be seen as unstable until the subscription billing period ends.</p>
+    #
+    # + endingBefore - A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list. 
+    # + expand - Specifies which fields in the response should be expanded. 
+    # + 'limit - A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10. 
+    # + startingAfter - A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list. For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list. 
+    # + return - Successful response. 
+    remote isolated function getSubscriptionItemsSubscriptionItemUsageRecordSummaries(string subscriptionItem, string? endingBefore = (), string[]? expand = (), int? 'limit = (), string? startingAfter = ()) returns UsageEventsResourceUsageRecordSummaryList|error {
+        string resourcePath = string `/v1/subscription_items/${getEncodedUri(subscriptionItem)}/usage_record_summaries`;
+        map<anydata> queryParam = {"ending_before": endingBefore, "expand": expand, "limit": 'limit, "starting_after": startingAfter};
+        map<Encoding> queryParamEncoding = {"expand": {style: DEEPOBJECT, explode: true}};
+        resourcePath = resourcePath + check getPathForQueryParam(queryParam, queryParamEncoding);
+        UsageEventsResourceUsageRecordSummaryList response = check self.clientEp->get(resourcePath);
+        return response;
+    }
+
     # <p>By default, returns a list of subscriptions that have not been canceled. In order to list canceled subscriptions, specify <code>status=canceled</code>.</p>
     #
     # + collectionMethod - The collection method of the subscriptions to retrieve. Either `charge_automatically` or `send_invoice`. 

--- a/openapi/stripe/openapi.yaml
+++ b/openapi/stripe/openapi.yaml
@@ -28707,6 +28707,117 @@ paths:
               schema:
                 "$ref": "#/components/schemas/error"
           description: Error response.
+  "/v1/subscription_items/{subscription_item}/usage_record_summaries":
+    get:
+      description: >-
+        <p>For the specified subscription item, returns a list of summary
+        objects. Each object in the list provides usage information that’s been
+        summarized from multiple usage records and over a subscription billing
+        period (e.g., 15 usage records in the month of September).</p>
+
+
+        <p>The list is sorted in reverse-chronological order (newest first). The
+        first list item represents the most current usage period that hasn’t
+        ended yet. Since new usage records can still be added, the returned
+        summary information for the subscription item’s ID should be seen as
+        unstable until the subscription billing period ends.</p>
+      operationId: GetSubscriptionItemsSubscriptionItemUsageRecordSummaries
+      parameters:
+        - description: >-
+            A cursor for use in pagination. `ending_before` is an object ID that
+            defines your place in the list. For instance, if you make a list
+            request and receive 100 objects, starting with `obj_bar`, your
+            subsequent call can include `ending_before=obj_bar` in order to
+            fetch the previous page of the list.
+          in: query
+          name: ending_before
+          required: false
+          schema:
+            maxLength: 5000
+            type: string
+          style: form
+        - description: Specifies which fields in the response should be expanded.
+          explode: true
+          in: query
+          name: expand
+          required: false
+          schema:
+            items:
+              maxLength: 5000
+              type: string
+            type: array
+          style: deepObject
+        - description: >-
+            A limit on the number of objects to be returned. Limit can range
+            between 1 and 100, and the default is 10.
+          in: query
+          name: limit
+          required: false
+          schema:
+            type: integer
+          style: form
+        - description: >-
+            A cursor for use in pagination. `starting_after` is an object ID
+            that defines your place in the list. For instance, if you make a
+            list request and receive 100 objects, ending with `obj_foo`, your
+            subsequent call can include `starting_after=obj_foo` in order to
+            fetch the next page of the list.
+          in: query
+          name: starting_after
+          required: false
+          schema:
+            maxLength: 5000
+            type: string
+          style: form
+        - in: path
+          name: subscription_item
+          required: true
+          schema:
+            type: string
+          style: simple
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                description: ''
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/usage_record_summary'
+                    type: array
+                  has_more:
+                    description: >-
+                      True if this list has another page of items after this one
+                      that can be fetched.
+                    type: boolean
+                  object:
+                    description: >-
+                      String representing the object's type. Objects of the same
+                      type share the same value. Always has the value `list`.
+                    enum:
+                      - list
+                    type: string
+                  url:
+                    description: The URL where this list can be accessed.
+                    maxLength: 5000
+                    type: string
+                required:
+                  - data
+                  - has_more
+                  - object
+                  - url
+                title: UsageEventsResourceUsageRecordSummaryList
+                type: object
+                x-expandableFields:
+                  - data
+          description: Successful response.
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+          description: Error response.
   "/v1/subscriptions":
     get:
       description: "<p>By default, returns a list of subscriptions that have not been

--- a/openapi/stripe/types.bal
+++ b/openapi/stripe/types.bal
@@ -1393,6 +1393,40 @@ public type RecurringPriceData1 record {
     string? unit_amount_decimal?;
 };
 
+public type Period record {
+    # The end date of this usage period. All usage up to and including this point in time is included.
+    int? end?;
+    # The start date of this usage period. All usage after this point in time is included.
+    int? 'start?;
+};
+
+public type UsageRecordSummary record {
+    # Unique identifier for the object.
+    string? id;
+    # The invoice in which this usage period has been billed for.
+    string? invoice?;
+    # Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+    boolean? livemode;
+    # String representing the object's type. Objects of the same type share the same value.
+    string? 'object;
+    #
+    Period? period;
+    # The ID of the subscription item this summary is describing.
+    string? subscription_item;
+    # The total usage within this usage period.
+    int? total_usage;
+};
+
+public type UsageEventsResourceUsageRecordSummaryList record {
+    UsageRecordSummary[]? data;
+    # True if this list has another page of items after this one that can be fetched.
+    boolean? has_more;
+    # String representing the object's type. Objects of the same type share the same value. Always has the value `list`.
+    string? 'object;
+    # The URL where this list can be accessed.
+    string? url;
+};
+
 public type V1CustomersBody record {
     # The customer's address.
     CustomerAdresss|string? address?;


### PR DESCRIPTION
# Description

Including ability to call
`GET /v1/subscription_items/:id/usage_record_summaries`


Related issue: https://github.com/wso2-enterprise/choreo/issues/18935


One line release note: 
- Add remote operation to retrieve usage_record_summaries for stripe connector

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

N/A

**Test Configuration**:
* Ballerina Version: 2201.2.3


# Checklist:

### Changes to OpenAPI definition

- [x] Modified `info` section of the OpenAPI definition file - [Example](https://github.com/ballerina-platform/ballerina-extended-library/discussions/74)

    - `description` - what the connector is about 
    - `x-ballerina-init-description` OpenAPI extension - connector initialization details 
    - `x-ballerina-display` OpenAPI extension - connector name and path to the connector icon 

- [x] Added proper description each API Key, if API Key authentication is defined in OpenAPI definition file 

### Verifying connector module

- [x] Compiled the connector successfully with the targeted ballerina version. 
- [x] Conducted smoke tests on the connector (Recommended when OpenAPI definition is obtain from an unofficial source)

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 