### PR TITLE
Update Google Vision connector category

### DIFF
--- a/openapi/googleapis.vision/Ballerina.toml
+++ b/openapi/googleapis.vision/Ballerina.toml
@@ -1,12 +1,12 @@
 [package]
 license = ["Apache-2.0"]
-keywords = ["AI/Google", "Cost/Freemium", "Vendor/Google"]
+keywords = ["AI/Images", "Cost/Freemium", "Vendor/Google"]
 org = "ballerinax"
 name = "googleapis.vision"
 icon = "icon.png"
 distribution = "2201.3.1"
 repository = "https://github.com/ballerina-platform/ballerinax-openapi-connectors"
-version = "1.5.0"
+version = "1.5.1"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

This is to move the Google Cloud Vision connector to the category AI/Images as part of an effort to move all AI connectors to a new category.

One line release note: 
- This will move the Google Cloud Vision connector to the category AI/Images.

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update
