### PR TITLE
Update worldbank connector to use http 1.1

### DIFF
--- a/openapi/worldbank/Ballerina.toml
+++ b/openapi/worldbank/Ballerina.toml
@@ -4,9 +4,9 @@ keywords = ["Business Intelligence/Analytics", "Cost/Free"]
 org = "ballerinax"
 name = "worldbank"
 icon = "icon.png"
-distribution = "2201.2.1"
+distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/ballerinax-openapi-connectors"
-version = "1.4.1"
+version = "1.5.0"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/worldbank/Package.md
+++ b/openapi/worldbank/Package.md
@@ -9,7 +9,7 @@ This package provides the capability to easily access World Bank knowledge base.
 ### Compatibility
 |                               | Version               |
 |-------------------------------|-----------------------|
-| Ballerina Language Version    | Swan Lake 2201.2.1      |
+| Ballerina Language Version    | Swan Lake 2201.4.1      |
 | API Version                   | v2                    |
 
 ## Report issues

--- a/openapi/worldbank/types.bal
+++ b/openapi/worldbank/types.bal
@@ -20,7 +20,7 @@ import ballerina/http;
 @display {label: "Connection Config"}
 public type ConnectionConfig record {|
     # The HTTP version understood by the client
-    http:HttpVersion httpVersion = http:HTTP_2_0;
+    http:HttpVersion httpVersion = http:HTTP_1_1;
     # Configurations related to HTTP/1.x protocol
     ClientHttp1Settings http1Settings?;
     # Configurations related to HTTP/2 protocol


### PR DESCRIPTION
# Description
- Update worldbank connector to use HTTP 1.1

# Reason
Currently the connector uses HTTP 2.0 and gives the below error
```
error: Forbidden {"statusCode":403,"headers":{"Connection":["keep-alive"],"content-length":["179"],"Content-Type":["text/html"],"Date":["Fri, 28 Apr 2023 04:05:49 GMT"],"Server":["Microsoft-Azure-Application-Gateway/v2"]},"body":"<html>
<head><title>403 Forbidden</title></head>
<body>
<center><h1>403 Forbidden</h1></center>
<hr><center>Microsoft-Azure-Application-Gateway/v2</center>
</body>
</html>
"}
```

But when changing to HTTP 1.1, it works fine
