### PR TITLE
Fix Payload binding error in Azure OpenAI Text connector

### DIFF
--- a/openapi/azure.openai.text/Ballerina.toml
+++ b/openapi/azure.openai.text/Ballerina.toml
@@ -6,7 +6,7 @@ name = "azure.openai.text"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/azure.openai.text"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/azure.openai.text/openapi.yaml
+++ b/openapi/azure.openai.text/openapi.yaml
@@ -222,6 +222,7 @@ paths:
                               items:
                                 type: integer
                         finish_reason:
+                          nullable: true
                           type: string
                   usage:
                     type: object

--- a/openapi/azure.openai.text/types.bal
+++ b/openapi/azure.openai.text/types.bal
@@ -6,7 +6,7 @@ public type ConnectionConfig record {|
     # Provides Auth configurations needed when communicating with a remote HTTP endpoint.
     http:BearerTokenConfig|ApiKeysConfig auth;
     # The HTTP version understood by the client
-    http:HttpVersion httpVersion = http:HTTP_1_1;
+    http:HttpVersion httpVersion = http:HTTP_2_0;
     # Configurations related to HTTP/1.x protocol
     ClientHttp1Settings http1Settings?;
     # Configurations related to HTTP/2 protocol
@@ -89,7 +89,7 @@ public type Inline_response_200_choices record {
     string text?;
     int index?;
     Inline_response_200_logprobs? logprobs?;
-    string finish_reason?;
+    string? finish_reason?;
 };
 
 public type Deploymentid_completions_body record {


### PR DESCRIPTION
# Description

Intermittent Payload binding error occurs when using Azure OpenAI Text connector.
```
 PayloadBindingClientError (\"Payload binding failed: \'map<json>\' value cannot be converted to \'azure.openai.text:Inline_response_200\': \n\t\tfield \'choices[0].finish_reason\' in record \'azure.openai.text:Inline_response_200_choices\' should be of type \'string\', found \'()\'\",error(\"{ballerina/lang.value}ConversionError\",message=\"\'map<json>\' value cannot be converted to \'azure.openai.text:Inline_response_200\': \n\t\tfield \'choices[0].finish_reason\' in record \'azure.openai.text:Inline_response_200_choices\' should be of type \'string\', found \'()\'\"))
```

Fixes [# (issue)](https://github.com/wso2-enterprise/choreo/issues/21060)



One line release note: 
- Fixes Intermittent Payload binding error in Azure OpenAI Text connector.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)