### PR TITLE
Update azure key vault connector

### DIFF
--- a/openapi/azure.keyvault/Ballerina.toml
+++ b/openapi/azure.keyvault/Ballerina.toml
@@ -6,7 +6,7 @@ name = "azure.keyvault"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/azure.keyvault"
-version = "1.5.1"
+version = "1.6.1"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/azure.keyvault/Module.md
+++ b/openapi/azure.keyvault/Module.md
@@ -19,13 +19,13 @@ import ballerinax/azure.keyvault;
 ### Step 2 - Create a new connector instance
 You can now make the connection configuration using the access token.
 ```ballerina
-keyvault:ClientConfig clientConfig = {
+keyvault:ConnectionConfig connectionConfig = {
     auth : {
         token: token
     }
 };
 
-keyvault:Client baseClient = check new Client(clientConfig, serviceUrl = "{vaultBaseUrl}");
+keyvault:Client baseClient = check new Client(connectionConfig, serviceUrl = "{vaultBaseUrl}");
 ```
 ### Step 3 - Invoke connector operation
 

--- a/openapi/azure.keyvault/original-openapi.yaml
+++ b/openapi/azure.keyvault/original-openapi.yaml
@@ -27,8 +27,6 @@ info:
   x-tags:
   - Azure
   - Microsoft
-x-ballerina-http-configurations:
-  httpVersion: "1.1"
 paths:
   /certificates:
     get:
@@ -5319,7 +5317,6 @@ components:
           type: string
           description: The URL to get the next set of certificate issuers.
           readOnly: true
-          nullable: true
         value:
           type: array
           description: A response message containing a list of certificate issuers
@@ -5382,7 +5379,6 @@ components:
           type: string
           description: The URL to get the next set of certificates.
           readOnly: true
-          nullable: true
         value:
           type: array
           description: A response message containing a list of certificates in the
@@ -5549,7 +5545,6 @@ components:
           type: string
           description: The URL to get the next set of deleted certificates.
           readOnly: true
-          nullable: true
         value:
           type: array
           description: A response message containing a list of deleted certificates
@@ -5575,7 +5570,6 @@ components:
           type: string
           description: The URL to get the next set of deleted keys.
           readOnly: true
-          nullable: true
         value:
           type: array
           description: A response message containing a list of deleted keys in the
@@ -5601,7 +5595,6 @@ components:
           type: string
           description: The URL to get the next set of deleted SAS definitions.
           readOnly: true
-          nullable: true
         value:
           type: array
           description: A response message containing a list of the deleted SAS definitions
@@ -5626,7 +5619,6 @@ components:
           type: string
           description: The URL to get the next set of deleted secrets.
           readOnly: true
-          nullable: true
         value:
           type: array
           description: A response message containing a list of the deleted secrets
@@ -5652,7 +5644,6 @@ components:
           type: string
           description: The URL to get the next set of deleted storage accounts.
           readOnly: true
-          nullable: true
         value:
           type: array
           description: A response message containing a list of the deleted storage
@@ -5972,7 +5963,6 @@ components:
           type: string
           description: The URL to get the next set of keys.
           readOnly: true
-          nullable: true
         value:
           type: array
           description: A response message containing a list of keys in the key vault
@@ -6374,7 +6364,6 @@ components:
           type: string
           description: The URL to get the next set of SAS definitions.
           readOnly: true
-          nullable: true
         value:
           type: array
           description: A response message containing a list of SAS definitions along
@@ -6475,7 +6464,6 @@ components:
           type: string
           description: The URL to get the next set of secrets.
           readOnly: true
-          nullable: true
         value:
           type: array
           description: A response message containing a list of secrets in the key
@@ -6688,7 +6676,6 @@ components:
           type: string
           description: The URL to get the next set of storage accounts.
           readOnly: true
-          nullable: true
         value:
           type: array
           description: A response message containing a list of storage accounts in

--- a/openapi/azure.keyvault/types.bal
+++ b/openapi/azure.keyvault/types.bal
@@ -23,7 +23,7 @@ public type ConnectionConfig record {|
     # Configurations related to client authentication
     http:BearerTokenConfig auth;
     # The HTTP version understood by the client
-    http:HttpVersion httpVersion = http:HTTP_2_0;
+    http:HttpVersion httpVersion = http:HTTP_1_1;
     # Configurations related to HTTP/1.x protocol
     ClientHttp1Settings http1Settings?;
     # Configurations related to HTTP/2 protocol
@@ -142,7 +142,7 @@ public type IssuerAttributes record {
 # A list of keys that have been deleted in this vault.
 public type DeletedKeyListResult record {
     # The URL to get the next set of deleted keys.
-    string nextLink?;
+    string? nextLink?;
     # A response message containing a list of deleted keys in the vault along with a link to the next page of deleted keys
     DeletedKeyItem[] value?;
 };
@@ -397,7 +397,7 @@ public type PendingCertificateSigningRequestResult record {
 # The deleted SAS definition list result
 public type DeletedSasDefinitionListResult record {
     # The URL to get the next set of deleted SAS definitions.
-    string nextLink?;
+    string? nextLink?;
     # A response message containing a list of the deleted SAS definitions in the vault along with a link to the next page of deleted sas definitions
     DeletedSasDefinitionItem[] value?;
 };
@@ -581,7 +581,7 @@ public type KeyImportParameters record {
 # The storage account SAS definition list result.
 public type SasDefinitionListResult record {
     # The URL to get the next set of SAS definitions.
-    string nextLink?;
+    string? nextLink?;
     # A response message containing a list of SAS definitions along with a link to the next page of SAS definitions.
     SasDefinitionItem[] value?;
 };
@@ -613,7 +613,7 @@ public type CertificateUpdateParameters record {
 # A list of certificates that have been deleted in this vault.
 public type DeletedCertificateListResult record {
     # The URL to get the next set of deleted certificates.
-    string nextLink?;
+    string? nextLink?;
     # A response message containing a list of deleted certificates in the vault along with a link to the next page of deleted certificates
     DeletedCertificateItem[] value?;
 };
@@ -674,7 +674,7 @@ public type SasDefinitionItem record {
 # The storage accounts list result.
 public type StorageListResult record {
     # The URL to get the next set of storage accounts.
-    string nextLink?;
+    string? nextLink?;
     # A response message containing a list of storage accounts in the key vault along with a link to the next page of storage accounts.
     StorageAccountItem[] value?;
 };
@@ -699,7 +699,7 @@ public type CertificateAttributes Attributes;
 # The certificate list result.
 public type CertificateListResult record {
     # The URL to get the next set of certificates.
-    string nextLink?;
+    string? nextLink?;
     # A response message containing a list of certificates in the key vault along with a link to the next page of certificates.
     CertificateItem[] value?;
 };
@@ -730,7 +730,7 @@ public type KeyAttributes Attributes;
 # The key list result.
 public type KeyListResult record {
     # The URL to get the next set of keys.
-    string nextLink?;
+    string? nextLink?;
     # A response message containing a list of keys in the key vault along with a link to the next page of keys.
     KeyItem[] value?;
 };
@@ -813,7 +813,7 @@ public type DeletedSecretItem SecretItem;
 # The deleted secret list result
 public type DeletedSecretListResult record {
     # The URL to get the next set of deleted secrets.
-    string nextLink?;
+    string? nextLink?;
     # A response message containing a list of the deleted secrets in the vault along with a link to the next page of deleted secrets
     DeletedSecretItem[] value?;
 };
@@ -889,7 +889,7 @@ public type SecretAttributes Attributes;
 # The secret list result.
 public type SecretListResult record {
     # The URL to get the next set of secrets.
-    string nextLink?;
+    string? nextLink?;
     # A response message containing a list of secrets in the key vault along with a link to the next page of secrets.
     SecretItem[] value?;
 };
@@ -897,7 +897,7 @@ public type SecretListResult record {
 # The certificate issuer list result.
 public type CertificateIssuerListResult record {
     # The URL to get the next set of certificate issuers.
-    string nextLink?;
+    string? nextLink?;
     # A response message containing a list of certificate issuers in the key vault along with a link to the next page of certificate issuers.
     CertificateIssuerItem[] value?;
 };
@@ -917,7 +917,7 @@ public type AdministratorDetails record {
 # The deleted storage account list result
 public type DeletedStorageListResult record {
     # The URL to get the next set of deleted storage accounts.
-    string nextLink?;
+    string? nextLink?;
     # A response message containing a list of the deleted storage accounts in the vault along with a link to the next page of deleted storage accounts
     DeletedStorageAccountItem[] value?;
 };


### PR DESCRIPTION
# Description

- Change default http version of the connector from HTTP/2 to HTTP/1.1
- Update the openAPI contract related to the `getSecrets` API to accept `null` responses from the server
- Update the client related documentation in `Module.md` 

Fixes https://github.com/ballerina-platform/ballerina-extended-library/issues/552

Related Pull Requests (remove if not relevant)
- Pull request 1
- Pull request 2

One line release note: 
- Release azure.keyvault connector version 1.6.1

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

test program sample:

```bal
import ballerina/io;
import ballerinax/azure.keyvault;

public function main() returns error? {
    keyvault:ConnectionConfig clientConfig = {
        auth : {
            token: "<access-token>"

        }
    };
    keyvault:Client baseClient = check new (clientConfig, serviceUrl = "https://<your-key-vault-name>.vault.azure.net/");
    keyvault:SecretListResult secrets = check baseClient->getSecrets("7.0");
    io:print(secrets);
}
```

**Test Configuration**:
* Ballerina Version: 2201.4.1 /  2201.7.1
* Operating System: Ubuntu
* Java SDK: Java 17

# Checklist:

### Changes to OpenAPI definition

- [ ] Modified `info` section of the OpenAPI definition file - [Example](https://github.com/ballerina-platform/ballerina-extended-library/discussions/74)

    - `description` - what the connector is about 
    - `x-ballerina-init-description` OpenAPI extension - connector initialization details 
    - `x-ballerina-display` OpenAPI extension - connector name and path to the connector icon 

- [ ] Added proper description each API Key, if API Key authentication is defined in OpenAPI definition file 

### Changes to connector module

- [ ] Added license header at the top of each .bal file. 
- [ ] Added Package.md as per the guide [here](https://github.com/ballerina-platform/ballerina-extended-library/discussions/77)
- [ ] Added Module.md for the module of the  connector as per the guide [here](https://github.com/ballerina-platform/ballerina-extended-library/discussions/78)
- [ ] Added connector icon to the root of the connector. Icon needs to be a `png` of 200x200 px size with name `icon.png`
- [ ] Added Ballerina.toml file with following information. For keywords refer to [guide](https://github.com/ballerina-platform/ballerina-extended-library/discussions/72)

### Verifying connector module

- [ ] Compiled the connector successfully with the targeted ballerina version. 
- [ ] Conducted smoke tests on the connector (Recommended when OpenAPI definition is obtain from an unofficial source)

### Security checks
 - [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 