### PR TITLE
Defer azure.openai.chat release: revert version to 3.0.2

### DIFF
--- a/openapi/azure.openai.chat/Ballerina.toml
+++ b/openapi/azure.openai.chat/Ballerina.toml
@@ -6,7 +6,7 @@ name = "azure.openai.chat"
 icon = "icon.png"
 distribution = "2201.8.4"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/azure.openai.chat"
-version = "3.0.3"
+version = "3.0.2"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true


### PR DESCRIPTION
## Summary
Revert \`openapi/azure.openai.chat/Ballerina.toml\` version from \`3.0.3\` back to \`3.0.2\` so the upcoming release (cut for the SAP S/4HANA connectors) does not publish it.

\`3.0.2\` is what's currently on Ballerina Central, so \`bal push\` for this connector becomes a no-op ("version already exists", caught silently by the release task).

The underlying schema change (\`ChatCompletionToolChoiceOption\` adding \`required\`, from PRs #846 / commits a6635ad6 and 9a38f21b) stays in the source — only the version marker is rolled back so it doesn't ship in this cycle.

## Test plan
- [ ] Confirm next release only pushes the 14 SAP S/4HANA connectors (grep release logs for \`bal push\` success lines)
- [ ] Re-bump \`azure.openai.chat\` in a follow-up PR before the next intended release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request reverts the version of the `azure.openai.chat` connector from 3.0.3 back to 3.0.2 in the package manifest. This change defers the release of this connector to a later release cycle, allowing the current release to focus exclusively on publishing the SAP S/4HANA connectors. The version revert ensures that `bal push` will recognize the connector version as already existing on Ballerina Central and will not republish it.

The underlying schema changes (including the ChatCompletionToolChoiceOption modifications) remain in the repository and will be included in a follow-up release when this connector is re-bumped to 3.0.3.

## Changes

- `openapi/azure.openai.chat/Ballerina.toml`: Version reverted from 3.0.3 to 3.0.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->