### PR TITLE
Defer 19 stale connector releases: roll versions back to Central state

### DIFF
--- a/openapi/azure.keyvault/Ballerina.toml
+++ b/openapi/azure.keyvault/Ballerina.toml
@@ -6,7 +6,7 @@ name = "azure.keyvault"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/azure.keyvault"
-version = "1.6.1"
+version = "1.6.0"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/azure.openai.chat/Ballerina.toml
+++ b/openapi/azure.openai.chat/Ballerina.toml
@@ -6,7 +6,7 @@ name = "azure.openai.chat"
 icon = "icon.png"
 distribution = "2201.8.4"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/azure.openai.chat"
-version = "3.0.3"
+version = "3.0.2"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/azure.openai.text/Ballerina.toml
+++ b/openapi/azure.openai.text/Ballerina.toml
@@ -6,7 +6,7 @@ name = "azure.openai.text"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/azure.openai.text"
-version = "1.0.4"
+version = "1.0.3"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/beezup.merchant/Ballerina.toml
+++ b/openapi/beezup.merchant/Ballerina.toml
@@ -6,5 +6,5 @@ name = "beezup.merchant"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/beezup.merchant"
-version = "1.6.1"
+version = "1.6.0"
 authors = ["Ballerina"]

--- a/openapi/box/Ballerina.toml
+++ b/openapi/box/Ballerina.toml
@@ -6,7 +6,7 @@ name = "box"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/box"
-version = "1.5.2"
+version = "1.5.1"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/graphhopper.directions/Ballerina.toml
+++ b/openapi/graphhopper.directions/Ballerina.toml
@@ -6,7 +6,7 @@ name = "graphhopper.directions"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/graphhopper.directions"
-version = "1.5.2"
+version = "1.5.1"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/impala/Ballerina.toml
+++ b/openapi/impala/Ballerina.toml
@@ -6,7 +6,7 @@ name = "impala"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/impala"
-version = "1.3.2"
+version = "1.3.1"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/livestorm/Ballerina.toml
+++ b/openapi/livestorm/Ballerina.toml
@@ -6,7 +6,7 @@ name = "livestorm"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/livestorm"
-version = "2.6.1"
+version = "2.6.0"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/openai.audio/Ballerina.toml
+++ b/openapi/openai.audio/Ballerina.toml
@@ -6,7 +6,7 @@ name = "openai.audio"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/openai.audio"
-version = "1.0.6"
+version = "1.0.5"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/openai.chat/Ballerina.toml
+++ b/openapi/openai.chat/Ballerina.toml
@@ -6,7 +6,7 @@ name = "openai.chat"
 icon = "icon.png"
 distribution = "2201.8.4"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/openai.chat"
-version = "2.0.2"
+version = "2.0.1"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/openai.embeddings/Ballerina.toml
+++ b/openapi/openai.embeddings/Ballerina.toml
@@ -6,7 +6,7 @@ name = "openai.embeddings"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/openai.embeddings"
-version = "1.0.6"
+version = "1.0.5"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/openai.finetunes/Ballerina.toml
+++ b/openapi/openai.finetunes/Ballerina.toml
@@ -6,7 +6,7 @@ name = "openai.finetunes"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/openai.finetunes"
-version = "1.0.6"
+version = "1.0.5"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/openai.images/Ballerina.toml
+++ b/openapi/openai.images/Ballerina.toml
@@ -6,7 +6,7 @@ name = "openai.images"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/openai.images"
-version = "1.0.6"
+version = "1.0.5"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/openai.moderations/Ballerina.toml
+++ b/openapi/openai.moderations/Ballerina.toml
@@ -6,7 +6,7 @@ name = "openai.moderations"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/openai.moderations"
-version = "1.0.6"
+version = "1.0.5"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/openai.text/Ballerina.toml
+++ b/openapi/openai.text/Ballerina.toml
@@ -6,7 +6,7 @@ name = "openai.text"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/openai.text"
-version = "1.0.6"
+version = "1.0.5"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/pagerduty/Ballerina.toml
+++ b/openapi/pagerduty/Ballerina.toml
@@ -6,7 +6,7 @@ name = "pagerduty"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/pagerduty"
-version = "1.5.2"
+version = "1.5.1"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/ronin/Ballerina.toml
+++ b/openapi/ronin/Ballerina.toml
@@ -6,5 +6,5 @@ name = "ronin"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/ronin"
-version = "1.5.3"
+version = "1.5.2"
 authors = ["Ballerina"]

--- a/openapi/shopify.admin/Ballerina.toml
+++ b/openapi/shopify.admin/Ballerina.toml
@@ -6,7 +6,7 @@ name = "shopify.admin"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/shopify.admin"
-version = "2.5.1"
+version = "2.5.0"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/stripe/Ballerina.toml
+++ b/openapi/stripe/Ballerina.toml
@@ -6,7 +6,7 @@ name = "stripe"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/stripe"
-version = "1.6.3"
+version = "1.6.2"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true


### PR DESCRIPTION
## Summary
Roll back \`Ballerina.toml\` versions on 19 connectors so the upcoming SAP S/4HANA-focused release does not unintentionally publish them. Each target version already exists on production Central, so \`bal push\` will silently fail (caught by the release task's try/catch) and the connector is effectively skipped.

These connectors all sit one patch ahead of Central in the repo — most because of the auto hash-update PR from a prior release that never actually shipped them, plus \`azure.openai.chat\` whose schema bump was deferred from this cycle. This aligns them with Central again.

| Connector | From | To |
|---|---|---|
| azure.keyvault | 1.6.1 | 1.6.0 |
| azure.openai.chat | 3.0.3 | 3.0.2 |
| azure.openai.text | 1.0.4 | 1.0.3 |
| beezup.merchant | 1.6.1 | 1.6.0 |
| box | 1.5.2 | 1.5.1 |
| graphhopper.directions | 1.5.2 | 1.5.1 |
| impala | 1.3.2 | 1.3.1 |
| livestorm | 2.6.1 | 2.6.0 |
| openai.audio | 1.0.6 | 1.0.5 |
| openai.chat | 2.0.2 | 2.0.1 |
| openai.embeddings | 1.0.6 | 1.0.5 |
| openai.finetunes | 1.0.6 | 1.0.5 |
| openai.images | 1.0.6 | 1.0.5 |
| openai.moderations | 1.0.6 | 1.0.5 |
| openai.text | 1.0.6 | 1.0.5 |
| pagerduty | 1.5.2 | 1.5.1 |
| ronin | 1.5.3 | 1.5.2 |
| shopify.admin | 2.5.1 | 2.5.0 |
| stripe | 1.6.3 | 1.6.2 |

\`alfresco\` (1.4.0) was in the same category but already exists on Central, so no change needed there.

The OpenAI cluster (audio/chat/embeddings/finetunes/images/moderations/text) and stripe are particularly important to defer — their canonical maintenance line lives in dedicated module repos at much higher major versions; publishing the stale 1.x/2.x artifacts from this repo would create parallel old versions on Central.

Supersedes #862 (now closed) which contained the \`azure.openai.chat\` change in isolation.

## Test plan
- [ ] Trigger a stage release; confirm none of these 19 appear under successful \`bal push\` lines in the job log
- [ ] Confirm only the 14 SAP S/4HANA connectors publish