### PR TITLE
Add deprecation notes for the connectors and minor bump

### DIFF
--- a/openapi/hubspot.crm.company/Ballerina.toml
+++ b/openapi/hubspot.crm.company/Ballerina.toml
@@ -6,7 +6,7 @@ name = "hubspot.crm.company"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/hubspot.crm.company"
-version = "2.3.1"
+version = "2.4.0"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/hubspot.crm.company/Module.md
+++ b/openapi/hubspot.crm.company/Module.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.crm.obj.companies`](https://central.ballerina.io/ballerinax/hubspot.crm.obj.companies/latest) instead. For association operations, use [`ballerinax/hubspot.crm.associations`](https://central.ballerina.io/ballerinax/hubspot.crm.associations/latest).
+
 ## Overview
 The HubSpot connector(https://www.hubspot.com/) OpenAPI specification. 
 

--- a/openapi/hubspot.crm.company/Package.md
+++ b/openapi/hubspot.crm.company/Package.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.crm.obj.companies`](https://central.ballerina.io/ballerinax/hubspot.crm.obj.companies/latest) instead. For association operations, use [`ballerinax/hubspot.crm.associations`](https://central.ballerina.io/ballerinax/hubspot.crm.associations/latest).
+
 Connects to [HubSpot CRM API](https://developers.hubspot.com/docs/api/overview) from Ballerina
 
 ## Package overview

--- a/openapi/hubspot.crm.contact/Ballerina.toml
+++ b/openapi/hubspot.crm.contact/Ballerina.toml
@@ -6,7 +6,7 @@ name = "hubspot.crm.contact"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/hubspot.crm.contact"
-version = "2.3.1"
+version = "2.4.0"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/hubspot.crm.contact/Module.md
+++ b/openapi/hubspot.crm.contact/Module.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.crm.obj.contacts`](https://central.ballerina.io/ballerinax/hubspot.crm.obj.contacts/latest) instead. For association operations, use [`ballerinax/hubspot.crm.associations`](https://central.ballerina.io/ballerinax/hubspot.crm.associations/latest).
+
 ## Overview
 The HubSpot connector(https://www.hubspot.com/) OpenAPI specification. 
 

--- a/openapi/hubspot.crm.contact/Package.md
+++ b/openapi/hubspot.crm.contact/Package.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.crm.obj.contacts`](https://central.ballerina.io/ballerinax/hubspot.crm.obj.contacts/latest) instead. For association operations, use [`ballerinax/hubspot.crm.associations`](https://central.ballerina.io/ballerinax/hubspot.crm.associations/latest).
+
 Connects to [HubSpot CRM API](https://developers.hubspot.com/docs/api/overview) from Ballerina
 
 ## Package overview

--- a/openapi/hubspot.crm.deal/Ballerina.toml
+++ b/openapi/hubspot.crm.deal/Ballerina.toml
@@ -6,7 +6,7 @@ name = "hubspot.crm.deal"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/hubspot.crm.deal"
-version = "2.3.1"
+version = "2.4.0"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/hubspot.crm.deal/Module.md
+++ b/openapi/hubspot.crm.deal/Module.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.crm.obj.deals`](https://central.ballerina.io/ballerinax/hubspot.crm.obj.deals/latest) instead. For association operations, use [`ballerinax/hubspot.crm.associations`](https://central.ballerina.io/ballerinax/hubspot.crm.associations/latest).
+
 ## Overview
 The HubSpot connector(https://www.hubspot.com/) OpenAPI specification. 
 

--- a/openapi/hubspot.crm.deal/Package.md
+++ b/openapi/hubspot.crm.deal/Package.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.crm.obj.deals`](https://central.ballerina.io/ballerinax/hubspot.crm.obj.deals/latest) instead. For association operations, use [`ballerinax/hubspot.crm.associations`](https://central.ballerina.io/ballerinax/hubspot.crm.associations/latest).
+
 Connects to [HubSpot CRM API](https://developers.hubspot.com/docs/api/overview) from Ballerina
 
 ## Package overview

--- a/openapi/hubspot.crm.feedback/Ballerina.toml
+++ b/openapi/hubspot.crm.feedback/Ballerina.toml
@@ -6,7 +6,7 @@ name = "hubspot.crm.feedback"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/hubspot.crm.feedback"
-version = "2.3.1"
+version = "2.4.0"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/hubspot.crm.feedback/Module.md
+++ b/openapi/hubspot.crm.feedback/Module.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.crm.obj.feedback`](https://central.ballerina.io/ballerinax/hubspot.crm.obj.feedback/latest) instead. For association operations, use [`ballerinax/hubspot.crm.associations`](https://central.ballerina.io/ballerinax/hubspot.crm.associations/latest).
+
 ## Overview
 The HubSpot connector(https://www.hubspot.com/) OpenAPI specification. 
 

--- a/openapi/hubspot.crm.feedback/Package.md
+++ b/openapi/hubspot.crm.feedback/Package.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.crm.obj.feedback`](https://central.ballerina.io/ballerinax/hubspot.crm.obj.feedback/latest) instead. For association operations, use [`ballerinax/hubspot.crm.associations`](https://central.ballerina.io/ballerinax/hubspot.crm.associations/latest).
+
 Connects to [HubSpot CRM API](https://developers.hubspot.com/docs/api/overview) from Ballerina
 
 ## Package overview

--- a/openapi/hubspot.crm.lineitem/Ballerina.toml
+++ b/openapi/hubspot.crm.lineitem/Ballerina.toml
@@ -6,7 +6,7 @@ name = "hubspot.crm.lineitem"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/hubspot.crm.lineitem"
-version = "2.3.1"
+version = "2.4.0"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/hubspot.crm.lineitem/Module.md
+++ b/openapi/hubspot.crm.lineitem/Module.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.crm.obj.lineitems`](https://central.ballerina.io/ballerinax/hubspot.crm.obj.lineitems/latest) instead. For association operations, use [`ballerinax/hubspot.crm.associations`](https://central.ballerina.io/ballerinax/hubspot.crm.associations/latest).
+
 ## Overview
 The HubSpot connector(https://www.hubspot.com/) OpenAPI specification. 
 

--- a/openapi/hubspot.crm.lineitem/Package.md
+++ b/openapi/hubspot.crm.lineitem/Package.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.crm.obj.lineitems`](https://central.ballerina.io/ballerinax/hubspot.crm.obj.lineitems/latest) instead. For association operations, use [`ballerinax/hubspot.crm.associations`](https://central.ballerina.io/ballerinax/hubspot.crm.associations/latest).
+
 Connects to [HubSpot CRM API](https://developers.hubspot.com/docs/api/overview) from Ballerina
 
 ## Package overview

--- a/openapi/hubspot.crm.pipeline/Ballerina.toml
+++ b/openapi/hubspot.crm.pipeline/Ballerina.toml
@@ -6,7 +6,7 @@ name = "hubspot.crm.pipeline"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/hubspot.crm.pipeline"
-version = "2.3.1"
+version = "2.4.0"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/hubspot.crm.pipeline/Module.md
+++ b/openapi/hubspot.crm.pipeline/Module.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.crm.pipelines`](https://central.ballerina.io/ballerinax/hubspot.crm.pipelines/latest) instead.
+
 ## Overview
 The HubSpot connector(https://www.hubspot.com/) OpenAPI specification. 
 

--- a/openapi/hubspot.crm.pipeline/Package.md
+++ b/openapi/hubspot.crm.pipeline/Package.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.crm.pipelines`](https://central.ballerina.io/ballerinax/hubspot.crm.pipelines/latest) instead.
+
 Connects to [HubSpot CRM API](https://developers.hubspot.com/docs/api/overview) from Ballerina
 
 ## Package overview

--- a/openapi/hubspot.crm.product/Ballerina.toml
+++ b/openapi/hubspot.crm.product/Ballerina.toml
@@ -6,7 +6,7 @@ name = "hubspot.crm.product"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/hubspot.crm.product"
-version = "2.3.1"
+version = "2.4.0"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/hubspot.crm.product/Module.md
+++ b/openapi/hubspot.crm.product/Module.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.crm.obj.products`](https://central.ballerina.io/ballerinax/hubspot.crm.obj.products/latest) instead. For association operations, use [`ballerinax/hubspot.crm.associations`](https://central.ballerina.io/ballerinax/hubspot.crm.associations/latest).
+
 ## Overview
 The HubSpot connector(https://www.hubspot.com/) OpenAPI specification. 
 

--- a/openapi/hubspot.crm.product/Package.md
+++ b/openapi/hubspot.crm.product/Package.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.crm.obj.products`](https://central.ballerina.io/ballerinax/hubspot.crm.obj.products/latest) instead. For association operations, use [`ballerinax/hubspot.crm.associations`](https://central.ballerina.io/ballerinax/hubspot.crm.associations/latest).
+
 Connects to [HubSpot CRM API](https://developers.hubspot.com/docs/api/overview) from Ballerina
 
 ## Package overview

--- a/openapi/hubspot.crm.property/Ballerina.toml
+++ b/openapi/hubspot.crm.property/Ballerina.toml
@@ -6,7 +6,7 @@ name = "hubspot.crm.property"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/hubspot.crm.property"
-version = "2.3.1"
+version = "2.4.0"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/hubspot.crm.property/Module.md
+++ b/openapi/hubspot.crm.property/Module.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.crm.properties`](https://central.ballerina.io/ballerinax/hubspot.crm.properties/latest) instead.
+
 ## Overview
 The HubSpot connector(https://www.hubspot.com/) OpenAPI specification. 
 

--- a/openapi/hubspot.crm.property/Package.md
+++ b/openapi/hubspot.crm.property/Package.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.crm.properties`](https://central.ballerina.io/ballerinax/hubspot.crm.properties/latest) instead.
+
 Connects to [HubSpot CRM API](https://developers.hubspot.com/docs/api/overview) from Ballerina
 
 ## Package overview

--- a/openapi/hubspot.crm.quote/Ballerina.toml
+++ b/openapi/hubspot.crm.quote/Ballerina.toml
@@ -6,7 +6,7 @@ name = "hubspot.crm.quote"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/hubspot.crm.quote"
-version = "2.3.1"
+version = "2.4.0"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/hubspot.crm.quote/Module.md
+++ b/openapi/hubspot.crm.quote/Module.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.crm.commerce.quotes`](https://central.ballerina.io/ballerinax/hubspot.crm.commerce.quotes/latest) instead. For association operations, use [`ballerinax/hubspot.crm.associations`](https://central.ballerina.io/ballerinax/hubspot.crm.associations/latest).
+
 ## Overview
 The HubSpot connector(https://www.hubspot.com/) OpenAPI specification. 
 

--- a/openapi/hubspot.crm.quote/Package.md
+++ b/openapi/hubspot.crm.quote/Package.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.crm.commerce.quotes`](https://central.ballerina.io/ballerinax/hubspot.crm.commerce.quotes/latest) instead. For association operations, use [`ballerinax/hubspot.crm.associations`](https://central.ballerina.io/ballerinax/hubspot.crm.associations/latest).
+
 Connects to [HubSpot CRM API](https://developers.hubspot.com/docs/api/overview) from Ballerina
 
 ## Package overview

--- a/openapi/hubspot.crm.ticket/Ballerina.toml
+++ b/openapi/hubspot.crm.ticket/Ballerina.toml
@@ -6,7 +6,7 @@ name = "hubspot.crm.ticket"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/hubspot.crm.ticket"
-version = "2.3.1"
+version = "2.4.0"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/hubspot.crm.ticket/Module.md
+++ b/openapi/hubspot.crm.ticket/Module.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.crm.obj.tickets`](https://central.ballerina.io/ballerinax/hubspot.crm.obj.tickets/latest) instead. For association operations, use [`ballerinax/hubspot.crm.associations`](https://central.ballerina.io/ballerinax/hubspot.crm.associations/latest).
+
 ## Overview
 The HubSpot connector(https://www.hubspot.com/) OpenAPI specification. 
 

--- a/openapi/hubspot.crm.ticket/Package.md
+++ b/openapi/hubspot.crm.ticket/Package.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.crm.obj.tickets`](https://central.ballerina.io/ballerinax/hubspot.crm.obj.tickets/latest) instead. For association operations, use [`ballerinax/hubspot.crm.associations`](https://central.ballerina.io/ballerinax/hubspot.crm.associations/latest).
+
 Connects to [HubSpot CRM API](https://developers.hubspot.com/docs/api/overview) from Ballerina
 
 ## Package overview

--- a/openapi/hubspot.marketing/Ballerina.toml
+++ b/openapi/hubspot.marketing/Ballerina.toml
@@ -6,7 +6,7 @@ name = "hubspot.marketing"
 icon = "icon.png"
 distribution = "2201.4.1"
 repository = "https://github.com/ballerina-platform/openapi-connectors/tree/main/openapi/hubspot.marketing"
-version = "2.3.1"
+version = "2.4.0"
 authors = ["Ballerina"]
 [build-options]
 observabilityIncluded = true

--- a/openapi/hubspot.marketing/Module.md
+++ b/openapi/hubspot.marketing/Module.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.marketing.events`](https://central.ballerina.io/ballerinax/hubspot.marketing.events/latest) instead.
+
 ## Overview
 The HubSpot connector(https://www.hubspot.com/) OpenAPI specification. 
 

--- a/openapi/hubspot.marketing/Package.md
+++ b/openapi/hubspot.marketing/Package.md
@@ -1,3 +1,5 @@
+> **Deprecation Notice:** This connector is deprecated and will no longer be maintained or updated. Use [`ballerinax/hubspot.marketing.events`](https://central.ballerina.io/ballerinax/hubspot.marketing.events/latest) instead.
+
 Connects to [HubSpot Marketing API](https://developers.hubspot.com/docs/api/overview) from Ballerina
 
 ## Package overview


### PR DESCRIPTION
##  Description

Prepares 11 HubSpot connectors for deprecation by adding user-facing deprecation notices and bumping to the next minor version.

 Fixes https://github.com/wso2-enterprise/integration-engineering/issues/1685


  - [x] This change requires a documentation update

  Changes

  Each of the 11 connectors below has:
  - Version bumped from 2.3.1 → 2.4.0
  - Package.md and Module.md updated with a deprecation notice blockquote pointing to the successor connector(s)

  | Deprecated Connector | Successor Connector(s) |
  |---|---|
  | `ballerinax/hubspot.crm.company` | `ballerinax/hubspot.crm.obj.companies` + `ballerinax/hubspot.crm.associations` |
  | `ballerinax/hubspot.crm.contact` | `ballerinax/hubspot.crm.obj.contacts` + `ballerinax/hubspot.crm.associations` |
  | `ballerinax/hubspot.crm.deal` | `ballerinax/hubspot.crm.obj.deals` + `ballerinax/hubspot.crm.associations` |
  | `ballerinax/hubspot.crm.feedback` | `ballerinax/hubspot.crm.obj.feedback` + `ballerinax/hubspot.crm.associations` |
  | `ballerinax/hubspot.crm.lineitem` | `ballerinax/hubspot.crm.obj.lineitems` + `ballerinax/hubspot.crm.associations` |
  | `ballerinax/hubspot.crm.pipeline` | `ballerinax/hubspot.crm.pipelines` |
  | `ballerinax/hubspot.crm.product` | `ballerinax/hubspot.crm.obj.products` + `ballerinax/hubspot.crm.associations` |
  | `ballerinax/hubspot.crm.property` | `ballerinax/hubspot.crm.properties` |
  | `ballerinax/hubspot.crm.quote` | `ballerinax/hubspot.crm.commerce.quotes` + `ballerinax/hubspot.crm.associations` |
  | `ballerinax/hubspot.crm.ticket` | `ballerinax/hubspot.crm.obj.tickets` + `ballerinax/hubspot.crm.associations` |
  | `ballerinax/hubspot.marketing` | `ballerinax/hubspot.marketing.events` |

  Checklist

  Changes to connector module

  - [x] Added Package.md deprecation notice for all 11 connectors
  - [x] Added Module.md deprecation notice for all 11 connectors
  - [x] Bumped minor version in Ballerina.toml for all 11 connectors

  Verifying connector module

  - [x] Successor packages verified to exist on Ballerina Central
  - [x] Successor packages verified to cover all operations from the deprecated connectors